### PR TITLE
fix: resolve errors and warnings in R CMD check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,11 +2,10 @@ Package: TCMDATA
 Title: Traditional Chinese Medicine Data Analysis and Visualization
 Version: 0.0.0.9000
 Authors@R: c(
-    person("Nan", "He", , "hinna@i.smu.edu.cn", role = c("aut", "cre")),
-    person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
-    person("Shuangbin", "Xu",       email = "xshuangbin@163.com",      role = "ctb", 
-            comment = c(ORCID="0000-0003-3513-5362"))
-    )
+    person(given = "Nan",         family = "He", email = "nanh302311@gmail.com",    role = c("aut", "cre"), comment = c(ORCID = "0009-0008-6932-3867")),
+    person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com", role = c("aut", "ths"), comment = c(ORCID = "0000-0002-6485-8781")),
+    person(given = "Shuangbin",   family = "Xu", email = "xshuangbin@163.com",      role = "ctb",           comment = c(ORCID = "0000-0003-3513-5362"))
+  )
 Description: An integrated R package for Traditional Chinese Medicine (TCM) pharmacology data retrieval, network analysis, and visualization. It provides tools for fetching herb-molecule-target interactions, constructing pharmacological networks, performing enrichment analysis, and generating publication-ready visualizations like Sankey plots, Venn diagrams, and docking result heatmaps.
 Depends:
     R (>= 3.5.0)

--- a/R/PPI_cluster.R
+++ b/R/PPI_cluster.R
@@ -181,7 +181,7 @@ run_louvain <- function(g, resolution = 1.0, weights = NULL) {
 #' @param g An \code{igraph} object. The graph must have a vertex attribute containing cluster labels.
 #' @param cluster_attr Character. The name of the vertex attribute that stores cluster labels. Default is louvain_cluster.
 #' @param min_size Integer. Clusters smaller than this size will be ignored. Default is 3.
-#'
+#' @param ... Additional arguments passed to `add_cluster_score` when using the deprecated alias `Addclusterscore`.
 #' @return A data frame containing cluster statistics, ranked by Score.
 #' @importFrom igraph vertex_attr vertex_attr_names induced_subgraph vcount edge_density V ecount
 #' @importFrom utils head
@@ -244,6 +244,7 @@ add_cluster_score <- function(g, cluster_attr = "louvain_cluster", min_size = 3)
   return(df_res)
 }
 
+#' @rdname add_cluster_score
 #' @export
 Addclusterscore <- function(...) {
   warning("Addclusterscore is deprecated. Please use add_cluster_score instead.")

--- a/R/PlotNodeHeatmap.R
+++ b/R/PlotNodeHeatmap.R
@@ -17,27 +17,27 @@
 #' p1 <- plot_node_heatmap(rk_res, select_cols = selected_cols)
 #' print(p1)
 #' @export
-plot_node_heatmap <- function(data, 
-                            id_col = "name", 
-                            select_cols = NULL, 
-                            colors = c("#2166AC", "white", "#B2182B"), 
-                            cluster_rows = TRUE, 
+plot_node_heatmap <- function(data,
+                            id_col = "name",
+                            select_cols = NULL,
+                            colors = c("#2166AC", "white", "#B2182B"),
+                            cluster_rows = TRUE,
                             cluster_cols = FALSE,
                             ...) {
-  
+
   # Check for ComplexHeatmap availability
   if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
     stop("Package 'ComplexHeatmap' is required but not installed. Please install it from Bioconductor using: BiocManager::install(\"ComplexHeatmap\")")
   }
-  
+
   if (!id_col %in% colnames(data)) {
     stop(paste("Error: The column", id_col, "does not exist in the input data."))
   }
-  
+
   plot_data <- data
   rownames(plot_data) <- plot_data[[id_col]]
-  plot_data[[id_col]] <- NULL 
-  
+  plot_data[[id_col]] <- NULL
+
   if (!is.null(select_cols)) {
     missing <- setdiff(select_cols, colnames(plot_data))
     if (length(missing) > 0) {
@@ -45,36 +45,37 @@ plot_node_heatmap <- function(data,
     }
     plot_data <- plot_data[, select_cols, drop = FALSE]
   }
-  
+
   is_num <- sapply(plot_data, is.numeric)
   plot_data <- plot_data[, is_num, drop = FALSE]
-  
+
   if (ncol(plot_data) == 0) {
     stop("Error: No numeric columns left to plot after selection.")
   }
-  
+
   # scale data and deal with NA
   mat_scaled <- scale(plot_data)
   mat_scaled[is.na(mat_scaled)] <- 0
-  
+
   # Color Mapping
   col_fun <- circlize::colorRamp2(c(-2, 0, 2), colors)
-  
+
   p <- ComplexHeatmap::Heatmap(matrix = mat_scaled,
                                name = "Z-score",
                                col = col_fun,
                                cluster_rows = cluster_rows,
                                cluster_columns = cluster_cols,
-                               rect_gp = gpar(col = "white", lwd = 1), 
-                               row_names_gp = gpar(fontsize = 12),     
-                               column_names_gp = gpar(fontsize = 10, fontface = "italic"), 
+                               rect_gp = gpar(col = "white", lwd = 1),
+                               row_names_gp = gpar(fontsize = 12),
+                               column_names_gp = gpar(fontsize = 10, fontface = "italic"),
                                column_names_rot = 45,
                                row_dend_width = unit(2, "cm"),
                                ...)
-  
+
   return(p)
 }
 
+#' @rdname plot_node_heatmap
 #' @export
 PlotNodeHeatmap <- function(...) {
   warning("PlotNodeHeatmap is deprecated. Please use plot_node_heatmap instead.")

--- a/R/TCM_sankey.R
+++ b/R/TCM_sankey.R
@@ -1,6 +1,5 @@
 #' TCM Sankey Plot for herb-molecule-target
 #'
-#'
 #' @param data A data frame containing at least three columns: \code{herb}, \code{molecule}, and \code{target}.
 #' @param axis_order Character vector specifying the order of axes in the Sankey diagram. Default is \code{c("herb", "molecule", "target")}.
 #' @param herb_cols Character vector defining the base color palette for the herb layer.
@@ -12,7 +11,7 @@
 #' @param width Numeric value controlling the width of both nodes and flows. Default is \code{0.05}.
 #' @param alpha Numeric value controlling the transparency of the flows. Default is \code{0.3}.
 #' @param knot.pos Numeric value (between 0 and 1) determining the curvature position of flow lines. Default is \code{0.3}.
-#'
+#' @param ... Additional arguments passed to `tcm_sankey` when using the deprecated alias `TCM_sankey`.
 #' @import ggplot2
 #' @importFrom dplyr count mutate group_by ungroup arrange select filter lead case_when all_of desc
 #' @importFrom RColorBrewer brewer.pal
@@ -127,6 +126,7 @@ tcm_sankey <- function(
 
 }
 
+#' @rdname tcm_sankey
 #' @export
 TCM_sankey <- function(...) {
   warning("TCM_sankey is deprecated. Please use tcm_sankey instead.")

--- a/R/pubchem_utils.R
+++ b/R/pubchem_utils.R
@@ -62,11 +62,13 @@ pug_request <- function(path, query = list(), body = NULL, method = c("GET","POS
 #' @return Character vector of CIDs (NA when not found).
 #'
 #' @examples
+#' \dontrun{
 #' herbs <- c("灵芝")
 #' lz <- search_herb(herb = herbs, type = "Herb_cn_name")
 #' lz_mol <- sample(unique(lz$molecule), 5, replace = FALSE)
 #' lz_mol_cid <- resolve_cid(lz_mol, from = "name")
 #' print(lz_mol_cid)
+#' }
 #' @export
 resolve_cid <- function(x, from = c("cid","smiles","inchi","inchikey","name")) {
   from <- match.arg(from)
@@ -142,9 +144,10 @@ resolve_cid <- function(x, from = c("cid","smiles","inchi","inchikey","name")) {
 #' @importFrom purrr map_chr slowly
 #' @importFrom tibble tibble
 #' @examples
+#' \dontrun{
 #' res_smiles <- getcid("CCO", from = "smiles")
 #' print(res_smiles)
-#'
+#' }
 #' @export
 getcid <- function(compound,
                    from = c("name", "smiles", "inchi"),

--- a/R/runMCODE.R
+++ b/R/runMCODE.R
@@ -9,14 +9,14 @@
 #' @param fdt Numeric. Fluff Node Density Cutoff. Used if fluff=TRUE. Default 0.1.
 #' @param loops Logical. Whether to include self-loops in scoring. Default FALSE.
 #' @param max_depth Numeric. Maximum recursion depth for cluster finding (to prevent stack overflow on huge networks). Default 100.
-#'
+#' @param ... Additional arguments passed to `run_mcode` when using the deprecated alias `runMCODE`.
 #' @importFrom igraph is_igraph simplify as_undirected induced_subgraph edge_density vcount V V<-
 #' @return An updated igraph object containing MCODE clustering result.
 #' @references Bader, G.D., Hogue, C.W. An automated method for finding molecular complexes in large protein interaction networks.
 #' BMC Bioinformatics 4, 2 (2003). https://doi.org/10.1186/1471-2105-4-2
 #' @examples
 #' data(demo_ppi)
-#' ppi <- runMCODE(demo_ppi, max_depth = 100)
+#' ppi <- run_mcode(demo_ppi, max_depth = 100)
 #' str(ppi)
 #'
 #' @export
@@ -278,6 +278,7 @@ run_mcode <- function(g,
 #'
 #' @param g An igraph object processed by \code{runMCODE}.
 #' @param only_clusters Logical. If TRUE, returns only nodes that belong to a cluster. Default FALSE.
+#' @param ... Additional arguments passed to `get_mcode_res` when using the deprecated alias `getMCODE_res`.
 #' @importFrom igraph is_igraph vertex_attr_names as_data_frame
 #' @return A data frame with columns:
 #' \item{name}{Gene Symbol / Node Name}
@@ -288,7 +289,7 @@ run_mcode <- function(g,
 #' @examples
 #' data(demo_ppi)
 #' ppi <- runMCODE(demo_ppi, max_depth = 100)
-#' MCODE_res <- getMCODE_res(ppi)
+#' MCODE_res <- get_mcode_res(ppi)
 #' print(head(MCODE_res))
 #' @export
 get_mcode_res <- function(g, only_clusters = FALSE) {
@@ -325,12 +326,14 @@ get_mcode_res <- function(g, only_clusters = FALSE) {
   return(res_df)
 }
 
+#' @rdname get_mcode_res
 #' @export
 getMCODE_res <- function(...) {
   warning("getMCODE_res is deprecated. Please use get_mcode_res instead.")
   get_mcode_res(...)
 }
 
+#' @rdname run_mcode
 #' @export
 runMCODE <- function(...) {
   warning("runMCODE is deprecated. Please use run_mcode instead.")

--- a/man/TCM_sankey.Rd
+++ b/man/TCM_sankey.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/TCM_sankey.R
 \name{tcm_sankey}
 \alias{tcm_sankey}
+\alias{TCM_sankey}
 \title{TCM Sankey Plot for herb-molecule-target}
 \usage{
 tcm_sankey(
@@ -20,6 +21,8 @@ tcm_sankey(
   alpha = 0.3,
   knot.pos = 0.3
 )
+
+TCM_sankey(...)
 }
 \arguments{
 \item{data}{A data frame containing at least three columns: \code{herb}, \code{molecule}, and \code{target}.}
@@ -43,6 +46,8 @@ tcm_sankey(
 \item{alpha}{Numeric value controlling the transparency of the flows. Default is \code{0.3}.}
 
 \item{knot.pos}{Numeric value (between 0 and 1) determining the curvature position of flow lines. Default is \code{0.3}.}
+
+\item{...}{Additional arguments passed to \code{tcm_sankey} when using the deprecated alias \code{TCM_sankey}.}
 }
 \value{
 A \code{ggplot} object representing the herb–compound–target Sankey diagram.

--- a/man/add_cluster_score.Rd
+++ b/man/add_cluster_score.Rd
@@ -2,9 +2,12 @@
 % Please edit documentation in R/PPI_cluster.R
 \name{add_cluster_score}
 \alias{add_cluster_score}
+\alias{Addclusterscore}
 \title{Score and Rank Network Clusters}
 \usage{
 add_cluster_score(g, cluster_attr = "louvain_cluster", min_size = 3)
+
+Addclusterscore(...)
 }
 \arguments{
 \item{g}{An \code{igraph} object. The graph must have a vertex attribute containing cluster labels.}
@@ -12,6 +15,8 @@ add_cluster_score(g, cluster_attr = "louvain_cluster", min_size = 3)
 \item{cluster_attr}{Character. The name of the vertex attribute that stores cluster labels. Default is louvain_cluster.}
 
 \item{min_size}{Integer. Clusters smaller than this size will be ignored. Default is 3.}
+
+\item{...}{Additional arguments passed to \code{add_cluster_score} when using the deprecated alias \code{Addclusterscore}.}
 }
 \value{
 A data frame containing cluster statistics, ranked by Score.

--- a/man/get_mcode_res.Rd
+++ b/man/get_mcode_res.Rd
@@ -2,14 +2,19 @@
 % Please edit documentation in R/runMCODE.R
 \name{get_mcode_res}
 \alias{get_mcode_res}
+\alias{getMCODE_res}
 \title{Extract MCODE analysis results as a data frame}
 \usage{
 get_mcode_res(g, only_clusters = FALSE)
+
+getMCODE_res(...)
 }
 \arguments{
 \item{g}{An igraph object processed by \code{runMCODE}.}
 
 \item{only_clusters}{Logical. If TRUE, returns only nodes that belong to a cluster. Default FALSE.}
+
+\item{...}{Additional arguments passed to \code{get_mcode_res} when using the deprecated alias \code{getMCODE_res}.}
 }
 \value{
 A data frame with columns:
@@ -25,6 +30,6 @@ Extract MCODE analysis results as a data frame
 \examples{
 data(demo_ppi)
 ppi <- runMCODE(demo_ppi, max_depth = 100)
-MCODE_res <- getMCODE_res(ppi)
+MCODE_res <- get_mcode_res(ppi)
 print(head(MCODE_res))
 }

--- a/man/getcid.Rd
+++ b/man/getcid.Rd
@@ -35,7 +35,8 @@ This function wraps \code{webchem::get_cid()} with built-in rate limiting
 (≤5 requests per second as recommended by PubChem).
 }
 \examples{
+\dontrun{
 res_smiles <- getcid("CCO", from = "smiles")
 print(res_smiles)
-
+}
 }

--- a/man/plot_node_heatmap.Rd
+++ b/man/plot_node_heatmap.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/PlotNodeHeatmap.R
 \name{plot_node_heatmap}
 \alias{plot_node_heatmap}
+\alias{PlotNodeHeatmap}
 \title{Plot PPI nodes metrics Heatmap}
 \usage{
 plot_node_heatmap(
@@ -13,6 +14,8 @@ plot_node_heatmap(
   cluster_cols = FALSE,
   ...
 )
+
+PlotNodeHeatmap(...)
 }
 \arguments{
 \item{data}{A data frame containing the nodes names and metric values.}

--- a/man/resolve_cid.Rd
+++ b/man/resolve_cid.Rd
@@ -21,9 +21,11 @@ it prefers POSTing the value in the request body to avoid URL length/encoding is
 and falls back to a GET path-style endpoint if needed.
 }
 \examples{
+\dontrun{
 herbs <- c("灵芝")
 lz <- search_herb(herb = herbs, type = "Herb_cn_name")
 lz_mol <- sample(unique(lz$molecule), 5, replace = FALSE)
 lz_mol_cid <- resolve_cid(lz_mol, from = "name")
 print(lz_mol_cid)
+}
 }

--- a/man/run_mcode.Rd
+++ b/man/run_mcode.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/runMCODE.R
 \name{run_mcode}
 \alias{run_mcode}
+\alias{runMCODE}
 \title{Molecular Complex Detection (MCODE) method for identifying PPI clusters.}
 \usage{
 run_mcode(
@@ -15,6 +16,8 @@ run_mcode(
   loops = FALSE,
   max_depth = 100
 )
+
+runMCODE(...)
 }
 \arguments{
 \item{g}{An igraph object (PPI network).}
@@ -34,6 +37,8 @@ run_mcode(
 \item{loops}{Logical. Whether to include self-loops in scoring. Default FALSE.}
 
 \item{max_depth}{Numeric. Maximum recursion depth for cluster finding (to prevent stack overflow on huge networks). Default 100.}
+
+\item{...}{Additional arguments passed to \code{run_mcode} when using the deprecated alias \code{runMCODE}.}
 }
 \value{
 An updated igraph object containing MCODE clustering result.
@@ -43,7 +48,7 @@ Molecular Complex Detection (MCODE) method for identifying PPI clusters.
 }
 \examples{
 data(demo_ppi)
-ppi <- runMCODE(demo_ppi, max_depth = 100)
+ppi <- run_mcode(demo_ppi, max_depth = 100)
 str(ppi)
 
 }


### PR DESCRIPTION
1. 把`pubchem_utils.R`的一些函数的examples设置为`dontrun`，因为有时候网络原因，检索化合物信息可能会花一些时间。
2. 修改`DESCRIPTION`文件和一些注释，以便通过R check。