### PR TITLE
fix: igraph bfs father->parent; enhance plot_node_heatmap params

### DIFF
--- a/R/PPI_utils.R
+++ b/R/PPI_utils.R
@@ -442,12 +442,12 @@ compute_BN <- function(g) {
       root        = s,
       mode        = "all",
       unreachable = FALSE,
-      father      = TRUE,
+      parent      = TRUE,
       dist        = TRUE
     )
 
     dist   <- as.numeric(bfs_res$dist)
-    father <- as.numeric(bfs_res$father)
+    parent <- as.numeric(bfs_res$parent)
 
     reachable_indices <- which(!is.na(dist))
     nT <- length(reachable_indices)
@@ -460,7 +460,7 @@ compute_BN <- function(g) {
     ord <- reachable_indices[order(dist[reachable_indices], decreasing = TRUE)]
 
     for (v in ord) {
-      p <- father[v]
+      p <- parent[v]
       if (!is.na(p) && p > 0 && p != v) {
         subtree_size[p] <- subtree_size[p] + subtree_size[v]
       }

--- a/R/PlotNodeHeatmap.R
+++ b/R/PlotNodeHeatmap.R
@@ -1,14 +1,48 @@
 #' Plot PPI nodes metrics Heatmap
 #'
-#' @param data A data frame containing the nodes names and metric values.
-#' @param id_col Character. The column name serving as row names. Default is "name".
-#' @param select_cols Character Vector. The specific columns to include in the heatmap. Default all columns except `id_col` are used.
-#' @param colors Vector of length 3. Colors for low (-2), zero (0), and high (2) values. Default is c("#2166AC", "white", "#B2182B").
-#' @param cluster_rows Logical. Whether to perform hierarchical clustering on rows. Default is TRUE.
-#' @param cluster_cols Logical. Whether to perform hierarchical clustering on columns. Default is FALSE.
-#' @param ... Additional arguments passed to `ComplexHeatmap::Heatmap`.
+#' Create a Z-score normalized heatmap of PPI node topological metrics using
+#' \code{ComplexHeatmap}.  Provides convenient parameters for the most common
+#' styling adjustments while still accepting any additional argument via
+#' \code{...}.
+#'
+#' @param data A data frame containing the node names and metric values.
+#' @param id_col Character. The column name serving as row identifiers.
+#'   Default is \code{"name"}.
+#' @param select_cols Character vector. Columns to include in the heatmap.
+#'   If \code{NULL} (default), all numeric columns except \code{id_col} are
+#'   used.
+#' @param colors Character vector of length 3. Colours mapped to Z-score
+#'   values \code{-2}, \code{0}, and \code{2}. Default is
+#'   \code{c("#2166AC", "white", "#B2182B")}.
+#' @param cluster_rows Logical. Perform hierarchical clustering on rows?
+#'   Default \code{TRUE}.
+#' @param cluster_cols Logical. Perform hierarchical clustering on columns?
+#'   Default \code{FALSE}.
+#' @param row_fontsize Numeric. Font size for row (gene) names.
+#'   Default \code{12}.
+#' @param row_fontface Character. Font face for row names. One of
+#'   \code{"plain"}, \code{"italic"}, \code{"bold"}, or
+#'   \code{"bold.italic"}. Default \code{"italic"}.
+#' @param col_fontsize Numeric. Font size for column (metric) names.
+#'   Default \code{10}.
+#' @param col_fontface Character. Font face for column names. Default
+#'   \code{"bold"}.
+#' @param col_rotation Numeric. Rotation angle (degrees) for column labels.
+#'   Default \code{45}.
+#' @param show_row_names Logical. Show row names? Default \code{TRUE}.
+#' @param show_column_names Logical. Show column names? Default \code{TRUE}.
+#' @param legend_title Character. Title for the colour legend. Default
+#'   \code{"Z-score"}.
+#' @param border_color Character. Cell border colour. Default \code{"white"}.
+#'   Set to \code{NA} to remove borders.
+#' @param border_width Numeric. Cell border line width. Default \code{1}.
+#' @param ... Additional arguments passed to
+#'   \code{\link[ComplexHeatmap]{Heatmap}}.
+#'
 #' @importFrom grid gpar unit
-#' @return A Heatmap object.
+#' @return A \code{Heatmap} object that can be printed or combined with other
+#'   heatmaps via \code{+} or \code{\%v\%}.
+#'
 #' @examples
 #' data(demo_ppi)
 #' ppi <- compute_nodeinfo(demo_ppi)
@@ -16,22 +50,33 @@
 #' selected_cols <- colnames(rk_res)[c(2, 3, 4, 6, 9, 12, 14, 15, 16)]
 #' p1 <- plot_node_heatmap(rk_res, select_cols = selected_cols)
 #' print(p1)
+#'
 #' @export
 plot_node_heatmap <- function(data,
-                            id_col = "name",
-                            select_cols = NULL,
-                            colors = c("#2166AC", "white", "#B2182B"),
-                            cluster_rows = TRUE,
-                            cluster_cols = FALSE,
-                            ...) {
+                              id_col = "name",
+                              select_cols = NULL,
+                              colors = c("#2166AC", "white", "#B2182B"),
+                              cluster_rows = TRUE,
+                              cluster_cols = FALSE,
+                              row_fontsize = 12,
+                              row_fontface = "italic",
+                              col_fontsize = 10,
+                              col_fontface = "bold",
+                              col_rotation = 45,
+                              show_row_names = TRUE,
+                              show_column_names = TRUE,
+                              legend_title = "Z-score",
+                              border_color = "white",
+                              border_width = 1,
+                              ...) {
 
-  # Check for ComplexHeatmap availability
   if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-    stop("Package 'ComplexHeatmap' is required but not installed. Please install it from Bioconductor using: BiocManager::install(\"ComplexHeatmap\")")
+    stop("Package 'ComplexHeatmap' is required. ",
+         "Install via: BiocManager::install(\"ComplexHeatmap\")")
   }
 
   if (!id_col %in% colnames(data)) {
-    stop(paste("Error: The column", id_col, "does not exist in the input data."))
+    stop("Column '", id_col, "' not found in the input data.")
   }
 
   plot_data <- data
@@ -41,36 +86,44 @@ plot_node_heatmap <- function(data,
   if (!is.null(select_cols)) {
     missing <- setdiff(select_cols, colnames(plot_data))
     if (length(missing) > 0) {
-      stop(paste("Error: The following columns were not found:", paste(missing, collapse=", ")))
+      stop("Columns not found: ", paste(missing, collapse = ", "))
     }
     plot_data <- plot_data[, select_cols, drop = FALSE]
   }
 
-  is_num <- sapply(plot_data, is.numeric)
+  is_num <- vapply(plot_data, is.numeric, logical(1))
   plot_data <- plot_data[, is_num, drop = FALSE]
 
   if (ncol(plot_data) == 0) {
-    stop("Error: No numeric columns left to plot after selection.")
+    stop("No numeric columns left to plot after selection.")
   }
 
-  # scale data and deal with NA
   mat_scaled <- scale(plot_data)
   mat_scaled[is.na(mat_scaled)] <- 0
 
-  # Color Mapping
   col_fun <- circlize::colorRamp2(c(-2, 0, 2), colors)
 
-  p <- ComplexHeatmap::Heatmap(matrix = mat_scaled,
-                               name = "Z-score",
-                               col = col_fun,
-                               cluster_rows = cluster_rows,
-                               cluster_columns = cluster_cols,
-                               rect_gp = gpar(col = "white", lwd = 1),
-                               row_names_gp = gpar(fontsize = 12),
-                               column_names_gp = gpar(fontsize = 10, fontface = "italic"),
-                               column_names_rot = 45,
-                               row_dend_width = unit(2, "cm"),
-                               ...)
+  rect_gp <- if (is.na(border_color)) {
+    gpar(col = NA)
+  } else {
+    gpar(col = border_color, lwd = border_width)
+  }
+
+  p <- ComplexHeatmap::Heatmap(
+    matrix            = mat_scaled,
+    name              = legend_title,
+    col               = col_fun,
+    cluster_rows      = cluster_rows,
+    cluster_columns   = cluster_cols,
+    show_row_names    = show_row_names,
+    show_column_names = show_column_names,
+    rect_gp           = rect_gp,
+    row_names_gp      = gpar(fontsize = row_fontsize, fontface = row_fontface),
+    column_names_gp   = gpar(fontsize = col_fontsize, fontface = col_fontface),
+    column_names_rot  = col_rotation,
+    row_dend_width    = unit(2, "cm"),
+    ...
+  )
 
   return(p)
 }

--- a/man/plot_node_heatmap.Rd
+++ b/man/plot_node_heatmap.Rd
@@ -12,31 +12,81 @@ plot_node_heatmap(
   colors = c("#2166AC", "white", "#B2182B"),
   cluster_rows = TRUE,
   cluster_cols = FALSE,
+  row_fontsize = 12,
+  row_fontface = "italic",
+  col_fontsize = 10,
+  col_fontface = "bold",
+  col_rotation = 45,
+  show_row_names = TRUE,
+  show_column_names = TRUE,
+  legend_title = "Z-score",
+  border_color = "white",
+  border_width = 1,
   ...
 )
 
 PlotNodeHeatmap(...)
 }
 \arguments{
-\item{data}{A data frame containing the nodes names and metric values.}
+\item{data}{A data frame containing the node names and metric values.}
 
-\item{id_col}{Character. The column name serving as row names. Default is "name".}
+\item{id_col}{Character. The column name serving as row identifiers.
+Default is \code{"name"}.}
 
-\item{select_cols}{Character Vector. The specific columns to include in the heatmap. Default all columns except \code{id_col} are used.}
+\item{select_cols}{Character vector. Columns to include in the heatmap.
+If \code{NULL} (default), all numeric columns except \code{id_col} are
+used.}
 
-\item{colors}{Vector of length 3. Colors for low (-2), zero (0), and high (2) values. Default is c("#2166AC", "white", "#B2182B").}
+\item{colors}{Character vector of length 3. Colours mapped to Z-score
+values \code{-2}, \code{0}, and \code{2}. Default is
+\code{c("#2166AC", "white", "#B2182B")}.}
 
-\item{cluster_rows}{Logical. Whether to perform hierarchical clustering on rows. Default is TRUE.}
+\item{cluster_rows}{Logical. Perform hierarchical clustering on rows?
+Default \code{TRUE}.}
 
-\item{cluster_cols}{Logical. Whether to perform hierarchical clustering on columns. Default is FALSE.}
+\item{cluster_cols}{Logical. Perform hierarchical clustering on columns?
+Default \code{FALSE}.}
 
-\item{...}{Additional arguments passed to \code{ComplexHeatmap::Heatmap}.}
+\item{row_fontsize}{Numeric. Font size for row (gene) names.
+Default \code{12}.}
+
+\item{row_fontface}{Character. Font face for row names. One of
+\code{"plain"}, \code{"italic"}, \code{"bold"}, or
+\code{"bold.italic"}. Default \code{"italic"}.}
+
+\item{col_fontsize}{Numeric. Font size for column (metric) names.
+Default \code{10}.}
+
+\item{col_fontface}{Character. Font face for column names. Default
+\code{"bold"}.}
+
+\item{col_rotation}{Numeric. Rotation angle (degrees) for column labels.
+Default \code{45}.}
+
+\item{show_row_names}{Logical. Show row names? Default \code{TRUE}.}
+
+\item{show_column_names}{Logical. Show column names? Default \code{TRUE}.}
+
+\item{legend_title}{Character. Title for the colour legend. Default
+\code{"Z-score"}.}
+
+\item{border_color}{Character. Cell border colour. Default \code{"white"}.
+Set to \code{NA} to remove borders.}
+
+\item{border_width}{Numeric. Cell border line width. Default \code{1}.}
+
+\item{...}{Additional arguments passed to
+\code{\link[ComplexHeatmap]{Heatmap}}.}
 }
 \value{
-A Heatmap object.
+A \code{Heatmap} object that can be printed or combined with other
+heatmaps via \code{+} or \code{\%v\%}.
 }
 \description{
-Plot PPI nodes metrics Heatmap
+Create a Z-score normalized heatmap of PPI node topological metrics using
+\code{ComplexHeatmap}.  Provides convenient parameters for the most common
+styling adjustments while still accepting any additional argument via
+\code{...}.
 }
 \examples{
 data(demo_ppi)
@@ -45,4 +95,5 @@ rk_res <- rank_ppi_nodes(ppi)[[2]]
 selected_cols <- colnames(rk_res)[c(2, 3, 4, 6, 9, 12, 14, 15, 16)]
 p1 <- plot_node_heatmap(rk_res, select_cols = selected_cols)
 print(p1)
+
 }


### PR DESCRIPTION
1. 解决`igraph`2.2.0版本中`father`参数被弃用的问题（改为`parent`）
2. 调整了`plot_node_heatmap()`的几个参数，支持基因名字体设定（如斜体）。