### PR TITLE
Fix AI module bugs and rewrite TCM skills

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -11,6 +11,7 @@ on:
       - aisdk
       - ppi_metrics_fix
       - skills
+      - master
 
 permissions:
   contents: write

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,7 +71,6 @@ Suggests:
     org.Hs.eg.db,
     DOSE
 Remotes:
-    YuLab-SMU/aisdk,
     YuLab-SMU/aplotExtra
 License: Artistic-2.0
 Encoding: UTF-8

--- a/R/ai_artifacts.R
+++ b/R/ai_artifacts.R
@@ -123,6 +123,25 @@ load_tcm_artifact <- function(artifact_id) {
   get(artifact_id, envir = .tcm_artifact_env)
 }
 
+#' Export one stored artifact to an R environment
+#' @keywords internal
+#' @noRd
+.export_tcm_artifact <- function(artifact_id, envir = globalenv()) {
+  assign(artifact_id, load_tcm_artifact(artifact_id), envir = envir)
+  invisible(artifact_id)
+}
+
+#' Export all stored artifacts to an R environment
+#' @keywords internal
+#' @noRd
+.export_tcm_artifacts <- function(envir = globalenv()) {
+  ids <- ls(.tcm_artifact_env)
+  for (id in ids) {
+    .export_tcm_artifact(id, envir = envir)
+  }
+  invisible(ids)
+}
+
 #' List all TCM artifacts in the registry
 #'
 #' Returns a data.frame summarizing all stored artifacts.

--- a/R/ai_core.R
+++ b/R/ai_core.R
@@ -12,7 +12,7 @@
   if (!requireNamespace("aisdk", quietly = TRUE)) {
     stop(
       "The 'aisdk' package is required for AI interpretation functions.\n",
-      "Install it with: devtools::install_github('YuLab-SMU/aisdk')",
+      "Install it with: install.packages('aisdk')",
       call. = FALSE
     )
   }
@@ -258,6 +258,10 @@ tcm_config <- function(provider,
 #'   the system message when \code{response_format} is absent).
 #'   Set \code{FALSE} only when targeting a provider whose API rejects an
 #'   unknown \code{response_format} field entirely.
+#' @param skip_internet_check Logical. Default \code{TRUE}. Sets
+#'   \code{options(aisdk.skip_internet_check = TRUE)} before live requests so
+#'   \code{curl::has_internet()} false negatives in proxy/VPN environments do
+#'   not block otherwise reachable API endpoints.
 #'
 #' @return The model object, invisibly.
 #' @examples
@@ -283,8 +287,13 @@ tcm_setup <- function(provider         = NULL,
                       .env             = TRUE,
                       save             = FALSE,
                       test             = FALSE,
-                      force_json_schema = TRUE) {
+                      force_json_schema = TRUE,
+                      skip_internet_check = TRUE) {
   .check_aisdk()
+
+  if (isTRUE(skip_internet_check)) {
+    options(aisdk.skip_internet_check = TRUE)
+  }
 
   if (.env && requireNamespace("dotenv", quietly = TRUE)) {
     env_file <- file.path(getwd(), ".env")
@@ -343,7 +352,11 @@ tcm_setup <- function(provider         = NULL,
 
   if (test) {
     tryCatch(
-      aisdk::generate_text(model = model_obj, prompt = "ping"),
+      aisdk::generate_text(
+        model = model_obj,
+        prompt = "ping",
+        temperature = NULL
+      ),
       error = function(e) warning(
         "Connection test failed: ", conditionMessage(e), call. = FALSE
       )

--- a/R/ai_task_agent.R
+++ b/R/ai_task_agent.R
@@ -87,7 +87,11 @@ run_tcm_task <- function(agent, task, model = NULL, verbose = TRUE) {
   }
 
   # Run the agent
-  result <- agent$run(task = resolved$resolved_task, model = model)
+  result <- agent$run(
+    task = resolved$resolved_task,
+    model = model,
+    temperature = NULL
+  )
 
   if (verbose) {
     cat("\n", result$text, "\n")
@@ -203,10 +207,10 @@ tcm_agent <- function(task,
 #' @param stream Logical. Enable streaming output (default TRUE). Toggle
 #'   at runtime with the \code{/stream} command.
 #' @param skills Character vector of skill directories to load for the chat
-#'   session. Default \code{NULL} uses the active TCMDATA skill directory
-#'   (scanning all skills under it) plus aisdk's \code{skill-creator} skill
-#'   if available. Use \code{character(0)} to disable skills, or pass an
-#'   explicit vector to override the default.
+#'   session. Default \code{NULL} disables aisdk skills for chat stability and
+#'   uses TCMDATA's built-in tool-oriented system prompt. Pass explicit skill
+#'   paths, for example \code{c(tcm_skill_dir(), tcm_aisdk_skill())}, to enable
+#'   skill loading.
 #'
 #' @return Invisibly returns a list with \code{history} (each turn's task and
 #'   reply) and \code{artifacts} (a data.frame snapshot from
@@ -263,7 +267,11 @@ tcm_chat <- function(model = NULL, verbose = TRUE, stream = TRUE,
   n_all_tools <- length(all_tools)
 
   # -- Create persistent chat session --
-  session_agent <- create_tcm_task_agent(tools = all_tools, skills = skills)
+  # Default chat turns should expose only TCMDATA analysis tools. Loading aisdk
+  # skills adds meta-tools such as load_skill, which some proxy-hosted models
+  # call with invalid empty arguments before doing the requested analysis.
+  chat_skills <- if (is.null(skills)) character(0) else skills
+  session_agent <- create_tcm_task_agent(tools = all_tools, skills = chat_skills)
   chat_session <- aisdk::create_chat_session(agent = session_agent, model = model)
 
   cat("\n")
@@ -281,6 +289,11 @@ tcm_chat <- function(model = NULL, verbose = TRUE, stream = TRUE,
 
   repeat {
     task <- readline(prompt = green_text("> "))
+    if (!interactive() && !nzchar(task)) {
+      cat("\n")
+      header("Session ended. No more input.")
+      break
+    }
     task <- trimws(task)
 
     if (nchar(task) == 0) next
@@ -505,27 +518,37 @@ tcm_chat <- function(model = NULL, verbose = TRUE, stream = TRUE,
         )
       }
 
-      # Streaming or batch execution
+      # Streaming or batch execution. Some OpenAI-compatible relay APIs reject
+      # stream + tools; retry the same turn without streaming before surfacing
+      # the error to the user.
       if (stream) {
-        stream_buf <- character(0)
         cat(bold_text(paste0("[", agent_name, "]")), "\n")
-        chat_session$send_stream(
-          prompt   = prompt,
-          turn_system_prompt = turn_ctx,
-          callback = function(chunk, done = FALSE) {
+      }
+      turn_result <- .send_tcm_chat_turn(
+        chat_session  = chat_session,
+        session_agent = session_agent,
+        model         = model,
+        prompt        = prompt,
+        turn_ctx      = turn_ctx,
+        stream        = stream,
+        callback      = function(chunk, done = FALSE) {
+          if (!is.null(chunk)) {
             cat(chunk)
-            stream_buf <<- c(stream_buf, chunk)
           }
-        )
-        cat("\n")
-        # Get text from session history
-        response_text <- chat_session$get_last_response()
-        if (is.null(response_text) || !nzchar(response_text)) {
-          response_text <- paste0(stream_buf, collapse = "")
+        },
+        on_stream_error = function(e) {
+          if (stream) {
+            cat("\n")
+            cat(yellow_text(
+              "  [stream failed; retrying this turn without streaming]\n"
+            ))
+          }
         }
-        result <- list(text = response_text, tool_calls = list())
-      } else {
-        result <- chat_session$send(prompt = prompt, turn_system_prompt = turn_ctx)
+      )
+      chat_session <- turn_result$chat_session
+      result <- turn_result$result
+      if (stream && !isTRUE(turn_result$fallback)) {
+        cat("\n")
       }
 
       # Tool call log
@@ -613,16 +636,17 @@ tcm_chat <- function(model = NULL, verbose = TRUE, stream = TRUE,
             chat_session$send_stream(
               prompt = verify_prompt,
               turn_system_prompt = turn_ctx,
+              temperature = NULL,
               callback = function(chunk, done = FALSE) {
                 cat(chunk)
-                stream_buf <<- c(stream_buf, chunk)
               }
             )
             cat("\n")
           } else {
             verify_result <- chat_session$send(
               prompt = verify_prompt,
-              turn_system_prompt = turn_ctx
+              turn_system_prompt = turn_ctx,
+              temperature = NULL
             )
             cat("\n", verify_result$text, "\n")
           }
@@ -657,6 +681,86 @@ tcm_chat <- function(model = NULL, verbose = TRUE, stream = TRUE,
     history   = history,
     artifacts = list_tcm_artifacts()
   ))
+}
+
+#' Send one tcm_chat turn, with stream-to-batch fallback
+#' @keywords internal
+#' @noRd
+.send_tcm_chat_turn <- function(chat_session,
+                                session_agent,
+                                model,
+                                prompt,
+                                turn_ctx = NULL,
+                                stream = TRUE,
+                                callback = NULL,
+                                on_stream_error = NULL) {
+  if (!isTRUE(stream)) {
+    result <- chat_session$send(
+      prompt = prompt,
+      turn_system_prompt = turn_ctx,
+      temperature = NULL
+    )
+    return(list(
+      result       = result,
+      chat_session = chat_session,
+      streamed     = FALSE,
+      fallback     = FALSE
+    ))
+  }
+
+  stream_buf <- character(0)
+  stream_error <- NULL
+  tryCatch(
+    chat_session$send_stream(
+      prompt = prompt,
+      turn_system_prompt = turn_ctx,
+      temperature = NULL,
+      callback = function(chunk, done = FALSE) {
+        if (!is.null(chunk)) {
+          stream_buf <<- c(stream_buf, chunk)
+        }
+        if (is.function(callback)) {
+          callback(chunk, done = done)
+        }
+      }
+    ),
+    error = function(e) {
+      stream_error <<- e
+    }
+  )
+
+  if (!is.null(stream_error)) {
+    if (is.function(on_stream_error)) {
+      on_stream_error(stream_error)
+    }
+    fallback_session <- aisdk::create_chat_session(
+      agent = session_agent,
+      model = model
+    )
+    result <- fallback_session$send(
+      prompt = prompt,
+      turn_system_prompt = turn_ctx,
+      temperature = NULL
+    )
+    return(list(
+      result       = result,
+      chat_session = fallback_session,
+      streamed     = FALSE,
+      fallback     = TRUE
+    ))
+  }
+
+  response_text <- chat_session$get_last_response()
+  if (is.null(response_text) || !nzchar(response_text)) {
+    response_text <- paste0(stream_buf, collapse = "")
+  }
+
+  list(
+    result       = list(text = response_text, tool_calls = list()),
+    chat_session = chat_session,
+    streamed     = TRUE,
+    fallback     = FALSE
+  )
 }
 
 #' Default system prompt for TCM task agent
@@ -935,7 +1039,7 @@ make_tcm_function <- function(instruction, name = "CustomFn") {
 run_tcm_agent <- function(agent, query, model = NULL, verbose = TRUE) {
   .check_aisdk()
   model <- .resolve_model(model)
-  result <- agent$run(task = query, model = model)
+  result <- agent$run(task = query, model = model, temperature = NULL)
   if (verbose) {
     cat(result$text, "\n")
     invisible(result$text)

--- a/R/ai_tools.R
+++ b/R/ai_tools.R
@@ -255,6 +255,7 @@ create_tcm_tools <- function(task_type = NULL, tool_names = NULL) {
       params = params
     )
   )
+  .export_tcm_artifact(artifact$artifact_id)
 
   base <- list(
     ok = TRUE,
@@ -2511,6 +2512,7 @@ tool_eval_r_code <- function() {
       "Execute a short R code snippet and return the output.",
       "The code runs in a sandboxed environment with access to base R, dplyr, and purrr.",
       "Variables from the user's globalenv() are accessible read-only.",
+      "TCMDATA artifact IDs returned by earlier tools are also available as variables.",
       "Use this for data transformations the user requests that no existing tool handles,",
       "such as subsetting, filtering, basic statistics, or preparing data for other tools.",
       "Keep code short (< 20 lines). Do NOT use this to install packages or write files."
@@ -2527,6 +2529,8 @@ tool_eval_r_code <- function() {
           return(list(ok = FALSE, error = "Code cannot be empty."))
         }
 
+        .export_tcm_artifacts()
+
         # Lazy-init sandbox with globalenv as parent for read access
         if (is.null(sandbox)) {
           sandbox <<- aisdk::SandboxManager$new(
@@ -2536,6 +2540,9 @@ tool_eval_r_code <- function() {
         }
 
         output <- sandbox$execute(code)
+        if (grepl("^Error executing R code:", output)) {
+          return(list(ok = FALSE, error = output))
+        }
         list(ok = TRUE, output = output)
       }, error = function(e) {
         list(ok = FALSE, error = conditionMessage(e))

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ TCMDATA integrates an AI agent layer via [aisdk](https://github.com/YuLab-SMU/ai
 
 ```r
 # One-time setup
-devtools::install_github("YuLab-SMU/aisdk")
+install.packages("aisdk")
 
 tcm_setup(
   provider = "openai",

--- a/docs/09-AI-module.Rmd
+++ b/docs/09-AI-module.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 The AI module requires both `TCMDATA` and `aisdk`:
 
 ```{r install, eval=FALSE}
-devtools::install_github("YuLab-SMU/aisdk")
+install.packages("aisdk")
 library(aisdk)
 library(TCMDATA)
 ```

--- a/inst/scripts/smoke_ai_module.R
+++ b/inst/scripts/smoke_ai_module.R
@@ -4,7 +4,7 @@
 # Does NOT require devtools::test() or a compiled package.
 #
 # Usage (from project root):
-#   source("tests/smoke_ai_module.R")
+#   source("inst/scripts/smoke_ai_module.R")
 #
 # Useful when devtools::test() is blocked (e.g. OpenMP shared-memory errors
 # in some environments). Mocks aisdk internals — no live API calls needed.
@@ -20,7 +20,9 @@ for (pkg in c("aisdk", "jsonlite", "igraph")) {
 message("Loading AI module source files...")
 invisible(lapply(
   c("R/ai_core.R", "R/ai_schema.R", "R/ai_analysis.R",
-    "R/ai_draft.R", "R/ai_agent.R",  "R/ai_print.R"),
+    "R/ai_draft.R", "R/ai_artifacts.R", "R/ai_router.R",
+    "R/ai_skills.R", "R/ai_tools.R", "R/ai_task_agent.R",
+    "R/ai_print.R"),
   source
 ))
 

--- a/inst/skills/tcm-network-pharmacology/SKILL.md
+++ b/inst/skills/tcm-network-pharmacology/SKILL.md
@@ -1,100 +1,91 @@
 ---
 name: tcm-network-pharmacology
 description: >
-  Domain knowledge and tool usage reference for TCM network pharmacology.
-  Consult this skill for parameter defaults, tool combinations, and quality
-  thresholds. This is a REFERENCE — not an execution plan.
-  Execute ONLY what the user asks for.
+  TCMDATA network pharmacology analysis skill for Traditional Chinese Medicine workflows in R.
+  Use when the user asks to query herbs, compounds, targets, disease genes, PubMed evidence,
+  molecule annotation, compound similarity, herb/disease target intersection, GO/KEGG/Herb
+  enrichment, GSEA, PPI network construction, topology calculation and ranking, community detection, PPI robustness
+  analysis, machine-learning key target screening, diagnostic ROC/boxplots, AI interpretation,
+  report drafting, or publication-style visualization for TCM network pharmacology. Also use
+  for Chinese requests such as 中药网络药理学分析, 靶点查询, 疾病靶点, 富集分析, PPI分析, 机器学习筛选,
+  分子注释, 文献挖掘, and AI模块.
 ---
 
-# TCM Network Pharmacology — Tool Reference
+# TCMDATA Network Pharmacology
 
-This document is a **look-up reference**, not an execution plan.
-Read the section relevant to the user's current request; ignore the rest.
+Use this skill as an execution guide for TCMDATA-based network pharmacology tasks. Execute exactly the analysis scope requested by the user. Do not expand a target query into a full pipeline unless the user explicitly asks for a complete, systematic, or network pharmacology analysis.
 
-## Core Principle
+## First Move
 
-**Do exactly what the user asks — nothing more, nothing less.**
+1. Identify the requested scope: lookup, molecule annotation, intersection, enrichment, PPI, machine learning, visualization, AI interpretation, or full pipeline.
+2. Load only the reference file needed for that scope.
+3. Prefer TCMDATA functions and built-in agent tools over ad hoc code.
+4. Preserve object names requested by the user, especially plot names such as `p_kegg`.
+5. Report exact counts, thresholds, and artifact IDs from tool outputs. Never invent genes, terms, p-values, pathways, or evidence.
 
-- "查黄芪靶点" → call `search_herb_records`, return results. Done.
-- "做个GO富集" → call `run_go_enrichment`. Done.
-- "找出黄芪靶点，然后做GO富集" → do BOTH: search + enrichment in one turn.
-- "做黄芪治疗脓毒症的网络药理学分析" → chain multiple tools as a full pipeline.
+## Reference Files
 
-Keyword signals for multi-step: 然后, 接着, 并且, and then, comma-separated actions.
-After completing ALL requested steps, you may mention 1–2 possible next steps but do NOT auto-execute them.
+| File | Open when |
+|------|-----------|
+| `references/workflow.md` | Need a full or partial analysis workflow covering all package documentation sections |
+| `references/function-reference.md` | Need exact function usage, parameter interpretation, or examples for any exported TCMDATA function |
+| `references/package-sections.md` | Need to ensure every documentation section is represented in a plan or answer |
+| `references/plotting-style.md` | Need publication-style R plots for enrichment, PPI, ML, network, docking, or report figures |
+| `references/quality-checkpoints.md` | Need thresholds, warnings, or sanity checks for target counts, intersections, PPI, enrichment, hubs, or literature |
+| `references/data-sources.md` | Need source grounding, evidence hierarchy, anti-hallucination rules, or cross-validation guidance |
 
-## Tool Quick Reference
+## Scope Rules
 
-| Task | Tool(s) | Key defaults |
-|------|---------|-------------|
-| Herb targets | `search_herb_records` | auto-detect type by input language |
-| Disease targets | `search_disease_targets` | — |
-| Target intersection | `compute_target_intersection` | supports 2/3/4-way |
-| PPI network | `get_ppi_network` → `compute_ppi_metrics` → `rank_ppi_nodes` | score_threshold=400, top_n=10 |
-| GO enrichment | `run_go_enrichment` | ontology="BP", p<0.05 |
-| KEGG enrichment | `run_kegg_enrichment` | p<0.05 |
-| Herb enrichment | `run_herb_enrichment` | — |
-| ML screening | `prepare_ml_dataset` → `run_ml_screening` → `get_ml_consensus` | min_methods=2 |
-| PubMed evidence | `get_pubmed_evidence` | max_results=20 |
-| Compound info | `resolve_compound_cid` → `get_compound_properties` | — |
-| GEO search | `search_geo_datasets` | organism="Homo sapiens" |
-| Visualization | `plot_enrichment_result`, `plot_ppi_result`, `plot_herb_sankey`, `plot_ml_result`, `plot_pubmed_result`, `plot_docking_heatmap` | — |
-| Interpretation | `interpret_artifact` | pass artifact_id |
+- For simple lookup requests, run only the relevant query function and summarize the result.
+- For enrichment requests, use the gene set explicitly requested. If the user says herb targets, use herb targets; if the user says herb-disease intersection, compute the intersection first.
+- For full network pharmacology requests, run target collection, intersection, PPI, enrichment, visualization, evidence validation, and report synthesis in that order.
+- For expression, DEG, WGCNA, ML, or single-cell validation, run those sections only when the user provides suitable data or explicitly asks to incorporate them.
+- For AI chat/tool workflows, use artifact IDs returned by tools; if executing R code in the same turn, load artifacts through `load_tcm_artifact()` or use exported artifact variables when available.
 
-## Parameter Defaults
+## Core Pipeline
 
-- **Herb name type**: Chinese characters → `"Herb_cn_name"`, capitalized → `"Herb_pinyin_name"`, lowercase → `"Herb_en_name"`
-- **PPI score**: 400 (medium). Use 700 for stringent.
-- **Enrichment cutoffs**: pvalueCutoff=0.05, qvalueCutoff=0.2
-- **Hub gene ranking**: composite hub_score from `rank_ppi_nodes`, top 10
+Use this order for a complete herb-disease network pharmacology analysis:
 
-## Quality Thresholds
+1. Herb targets: `search_herb()`
+2. Disease targets: `search_disease()`
+3. Intersection: `getvenndata()` / `getvennresult()` or the agent intersection tool
+4. PPI: `get_ppi()` -> `compute_nodeinfo()` -> `rank_ppi_nodes()`
+5. Community and robustness when requested: `run_louvain()`, `run_mcode()`, `run_MCL()`, `run_fastgreedy()`, `ppi_knock()`
+6. Enrichment: `herb_enricher()` and standard GO/KEGG workflows from `workflow.md`
+7. Machine learning when expression data is present: `prepare_ml_data()` -> `run_ml_screening()` -> `get_ml_consensus()`
+8. Visualization: select plots from `plotting-style.md` and `function-reference.md`
+9. Evidence and interpretation: `get_pubmed_data()`, `get_pubmed_table()`, `tcm_interpret()`, `draft_result_paragraph()`
 
-- Intersection < 5 genes → warn user, suggest relaxing parameters
-- Intersection > 500 genes → suggest narrowing disease scope
-- PPI < 10 edges → try lowering score_threshold to 150
-- Enrichment 0 significant terms → suggest relaxing cutoffs
-- PubMed 0 results → report honestly, do NOT fabricate evidence
+Key rule: use intersection genes, not all herb or disease genes, for downstream PPI/enrichment when the user asks for herb-disease mechanism analysis.
 
-## Data Integrity Rules
+## Reporting Rules
 
-- NEVER fabricate gene names, pathway names, or p-values
-- ALWAYS cite exact numbers from tool outputs
-- Distinguish evidence levels: clinical (HERB 2.0) > experimental > computational (TCMDATA) > single-database
-- Use `generate_verification_urls` for cross-validation links when reporting key findings
+- State source and exact counts: herb records, unique targets, disease genes, intersection size, PPI nodes/edges, significant terms, selected hub genes.
+- Use adjusted p-values for enrichment claims.
+- Distinguish computational predictions from experimental, literature, or clinical evidence.
+- Mention empty results honestly and suggest parameter relaxation only after reporting the failure.
+- Keep Chinese answers in Chinese unless the user requests English.
 
-## Multi-Step Pipeline (only when explicitly requested)
+## Minimal Report Template
 
-When the user asks for a "complete analysis", "network pharmacology", or "full pipeline":
-
-1. **Targets**: herb targets + disease targets → intersection
-2. **Network**: PPI → metrics → hub genes
-3. **Enrichment**: GO-BP + KEGG on intersection genes
-4. **Visualization**: sankey + PPI heatmap + enrichment lollipop
-5. **Validation** (optional): PubMed evidence + cross-DB links
-6. **Expression** (if data provided): WGCNA / ML / DEG integration
-7. **Report**: structured summary with numbers from each step
-
-Key rule for pipelines: always compute intersection BEFORE PPI/enrichment.
-Use intersection genes (not herb or disease genes alone) for downstream analysis.
-
-## Report Template (for full pipeline only)
-
-```
-## [Herb] treats [Disease] — Network Pharmacology
+```markdown
+## [Herb] - [Disease] Network Pharmacology
 
 ### Target Retrieval
-- Herb targets: [N] (TCMDATA) | Disease targets: [N] (DisGeNET)
-- Intersection: [N] common targets
+- Herb targets: [N]
+- Disease genes: [N]
+- Common targets: [N]
 
-### PPI & Hub Genes
-- Network: [N] nodes, [M] edges (STRING ≥ [threshold])
-- Top hub genes: [list]
+### PPI and Hub Genes
+- STRING threshold: [score]
+- Network: [nodes] nodes, [edges] edges
+- Top hub genes: [genes]
 
-### Enrichment
-- GO-BP: [top 3] | KEGG: [top 3]
+### Functional Enrichment
+- GO-BP top terms: [terms with adjusted p-values]
+- KEGG top pathways: [pathways with adjusted p-values]
 
-### Key Findings
-[Grounded interpretation]
+### Evidence and Interpretation
+- PubMed evidence: [N] records
+- Mechanistic summary: [grounded interpretation]
 ```

--- a/inst/skills/tcm-network-pharmacology/agents/openai.yaml
+++ b/inst/skills/tcm-network-pharmacology/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "TCM Network Pharmacology"
+  short_description: "TCMDATA workflows, functions, and plotting"
+  default_prompt: "Use $tcm-network-pharmacology to run a grounded TCMDATA network pharmacology analysis."
+
+policy:
+  allow_implicit_invocation: true

--- a/inst/skills/tcm-network-pharmacology/references/function-reference.md
+++ b/inst/skills/tcm-network-pharmacology/references/function-reference.md
@@ -1,0 +1,4128 @@
+# TCMDATA Function Reference
+
+Use this file when the user asks for exact function parameters or examples. Each exported function below includes usage, parameter interpretation, and a runnable or fill-in usage pattern. Prefer examples from package documentation when present; otherwise adapt the minimal pattern to the current objects.
+
+## PPI network and topology
+
+### `add_cluster_score()`
+
+Score and Rank Network Clusters
+
+This function evaluates the clusters/modules identified in the graph.
+It calculates a score for each cluster based on density and size (MCODE style),
+and returns a ranked data frame.
+
+Usage:
+```r
+add_cluster_score(g, cluster_attr = "louvain_cluster", min_size = 3)
+
+Addclusterscore(...)
+```
+
+参数解析:
+- `g`: An igraph object. The graph must have a vertex attribute containing cluster labels.
+- `cluster_attr`: Character. The name of the vertex attribute that stores cluster labels. Default is louvain_cluster.
+- `min_size`: Integer. Clusters smaller than this size will be ignored. Default is 3.
+- `...`: Additional arguments passed to add_cluster_score when using the deprecated alias Addclusterscore.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- run_louvain(demo_ppi, resolution = 1)
+louvain_score <- add_cluster_score(ppi, cluster_attr = "louvain_cluster", min_size = 3)
+head(louvain_score)
+```
+
+### `Addclusterscore()`
+
+Score and Rank Network Clusters
+
+This function evaluates the clusters/modules identified in the graph.
+It calculates a score for each cluster based on density and size (MCODE style),
+and returns a ranked data frame.
+
+Usage:
+```r
+add_cluster_score(g, cluster_attr = "louvain_cluster", min_size = 3)
+
+Addclusterscore(...)
+```
+
+参数解析:
+- `g`: An igraph object. The graph must have a vertex attribute containing cluster labels.
+- `cluster_attr`: Character. The name of the vertex attribute that stores cluster labels. Default is louvain_cluster.
+- `min_size`: Integer. Clusters smaller than this size will be ignored. Default is 3.
+- `...`: Additional arguments passed to add_cluster_score when using the deprecated alias Addclusterscore.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- run_louvain(demo_ppi, resolution = 1)
+louvain_score <- add_cluster_score(ppi, cluster_attr = "louvain_cluster", min_size = 3)
+head(louvain_score)
+```
+
+### `compute_nodeinfo()`
+
+Compute some useful metrics for PPI nodes
+
+Compute some useful metrics for PPI nodes
+
+Usage:
+```r
+compute_nodeinfo(g, weight_attr = "score", normalize = FALSE, seed = 42)
+```
+
+参数解析:
+- `g`: An igraph object containing PPI information.
+- `weight_attr`: Character; The attribute of weight in this PPI object.
+- `normalize`: Logical; whether to normalize betweenness and closeness centrality to the range [0, 1]. When TRUE, each value is divided by the theoretical maximum.
+- `seed`: Numeric; Random seed for function compute_EPC. Default is 42.
+
+使用示例:
+```r
+data(demo_ppi)
+library(igraph)
+ppi <- compute_nodeinfo(demo_ppi, weight_attr = "score")
+str(ppi)
+```
+
+### `get_mcode_res()`
+
+Extract MCODE analysis results as a data frame
+
+Extract MCODE analysis results as a data frame
+
+Usage:
+```r
+get_mcode_res(g, only_clusters = FALSE)
+
+getMCODE_res(...)
+```
+
+参数解析:
+- `g`: An igraph object processed by runMCODE.
+- `only_clusters`: Logical. If TRUE, returns only nodes that belong to a cluster. Default FALSE.
+- `...`: Additional arguments passed to get_mcode_res when using the deprecated alias getMCODE_res.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- runMCODE(demo_ppi, max_depth = 100)
+MCODE_res <- get_mcode_res(ppi)
+print(head(MCODE_res))
+```
+
+### `get_node_profile()`
+
+Extract normalized centrality profile for a node
+
+This function extracts selected metrics for a given node and normalizes
+them to the range [0, 1] for use in plots such as radar charts.
+
+Usage:
+```r
+get_node_profile(
+tab,
+node_name,
+metrics = c("degree", "betweenness", "closeness", "MCC", "MNC", "DMNC", "coreness",
+"EPC")
+)
+```
+
+参数解析:
+- `tab`: A data frame containing at least a name column and the specified metric columns.
+- `node_name`: Character; node name to extract.
+- `metrics`: Character vector; names of metric columns to use. Defaults to common centrality measures.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+get_node_profile(
+tab,
+node_name,
+metrics = c("degree", "betweenness", "closeness", "MCC", "MNC", "DMNC", "coreness",
+"EPC")
+)
+```
+
+### `get_ppi()`
+
+Retrieve a STRING PPI network
+
+Thin wrapper around clusterProfiler::getPPI() so the function is
+available directly from TCMDATA.
+
+Usage:
+```r
+get_ppi(x, taxID = "auto", ...)
+```
+
+参数解析:
+- `x`: An enrichResult object or a character vector of proteins.
+- `taxID`: NCBI taxonomy identifier. Use "auto" to let
+clusterProfiler::getPPI() infer it from an enrichResult
+when possible.
+- `...`: Additional arguments passed to clusterProfiler::getPPI(),
+such as ID, required_score, network_type,
+add_nodes, show_query_node_labels, and output.
+
+使用示例:
+```r
+genes <- c("TP53", "BRCA1", "AKT1", "EGFR")
+g <- get_ppi(genes, taxID = 9606)
+```
+
+### `interpret_ppi()`
+
+Interpret PPI network analysis results with AI
+
+Interpret PPI network analysis results with AI
+
+Usage:
+```r
+interpret_ppi(
+x,
+top_n = 10,
+audience = "researcher",
+language = c("zh", "en"),
+role = NULL,
+system = NULL,
+prompt = NULL,
+model = NULL
+)
+```
+
+参数解析:
+- `x`: An igraph object with vertex attributes from
+compute_nodeinfo(), a node-metric data.frame, or the list
+output of rank_ppi_nodes().
+- `top_n`: Integer. Number of top nodes. Default 10.
+- `audience`: Character. Default "researcher".
+Also accepts free-text descriptions.
+- `language`: Character. Default "zh".
+- `role`: Character or NULL. The AI's identity description. Replaces the
+default opening line; other constraints are preserved. Ignored when
+system is provided.
+- `system`: Character or NULL. Full system prompt override.
+- `prompt`: Character or NULL. Custom user prompt instruction.
+- `model`: Model identifier or NULL.
+
+使用示例:
+```r
+ppi <- compute_nodeinfo(demo_ppi)
+interpret_ppi(ppi)
+interpret_ppi(ppi, role = "You are a systems biology expert focusing on hub gene identification.")
+```
+
+### `plot_node_heatmap()`
+
+Plot PPI nodes metrics Heatmap
+
+Create a Z-score normalized heatmap of PPI node topological metrics using
+ComplexHeatmap.  Provides convenient parameters for the most common
+styling adjustments while still accepting any additional argument via
+....
+
+Usage:
+```r
+plot_node_heatmap(
+data,
+id_col = "name",
+select_cols = NULL,
+colors = c("#2166AC", "white", "#B2182B"),
+cluster_rows = TRUE,
+cluster_cols = FALSE,
+row_fontsize = 12,
+row_fontface = "italic",
+col_fontsize = 10,
+col_fontface = "bold",
+col_rotation = 45,
+show_row_names = TRUE,
+show_column_names = TRUE,
+legend_title = "Z-score",
+border_color = "white",
+border_width = 1,
+...
+)
+
+PlotNodeHeatmap(...)
+```
+
+参数解析:
+- `data`: A data frame containing the node names and metric values.
+- `id_col`: Character. The column name serving as row identifiers.
+Default is "name".
+- `select_cols`: Character vector. Columns to include in the heatmap.
+If NULL (default), all numeric columns except id_col are
+used.
+- `colors`: Character vector of length 3. Colours mapped to Z-score
+values -2, 0, and 2. Default is
+c("#2166AC", "white", "#B2182B").
+- `cluster_rows`: Logical. Perform hierarchical clustering on rows?
+Default TRUE.
+- `cluster_cols`: Logical. Perform hierarchical clustering on columns?
+Default FALSE.
+- `row_fontsize`: Numeric. Font size for row (gene) names.
+Default 12.
+- `row_fontface`: Character. Font face for row names. One of
+"plain", "italic", "bold", or
+"bold.italic". Default "italic".
+- `col_fontsize`: Numeric. Font size for column (metric) names.
+Default 10.
+- `col_fontface`: Character. Font face for column names. Default
+"bold".
+- `col_rotation`: Numeric. Rotation angle (degrees) for column labels.
+Default 45.
+- `show_row_names`: Logical. Show row names? Default TRUE.
+- `show_column_names`: Logical. Show column names? Default TRUE.
+- `legend_title`: Character. Title for the colour legend. Default
+"Z-score".
+- `border_color`: Character. Cell border colour. Default "white".
+Set to NA to remove borders.
+- `border_width`: Numeric. Cell border line width. Default 1.
+- `...`: Additional arguments passed to
+Heatmap.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- compute_nodeinfo(demo_ppi)
+rk_res <- rank_ppi_nodes(ppi)[[2]]
+selected_cols <- colnames(rk_res)[c(2, 3, 4, 6, 9, 12, 14, 15, 16)]
+p1 <- plot_node_heatmap(rk_res, select_cols = selected_cols)
+print(p1)
+```
+
+### `ppi_knock()`
+
+Evaluate PPI network robustness via drug attack model
+
+Simulates a targeted node-knockout attack on a weighted PPI network and
+evaluates the statistical significance of network disruption using a
+permutation test.  Four topological metrics are tracked (ASPL, AD, DC, CC),
+exactly following the methodology of Xi et al. (2022).
+
+Usage:
+```r
+ppi_knock(
+g,
+targets,
+n_perm = 100L,
+weight_attr = "score",
+rewire_niter = 10L,
+seed = 42L
+)
+```
+
+参数解析:
+- `g`: An undirected igraph object representing the PPI network.
+- `targets`: Character vector of node names to knock out (drug targets).
+- `n_perm`: Integer. Number of permutation iterations for the null
+distribution.  Default is 100, matching the original paper.
+- `weight_attr`: Character. Edge attribute name for confidence weights.
+Default is "score".
+- `rewire_niter`: Integer. Multiplier for edge-swap attempts per rewiring
+step (ecount(g) * rewire_niter swaps).  Default is 10.
+- `seed`: Integer. Random seed for reproducibility. Default is 42.
+
+使用示例:
+```r
+data(demo_ppi)
+targets <- "IL6"
+res <- ppi_knock(demo_ppi, targets, n_perm = 100)
+print(res$Summary)
+cat("Total Score:", res$Total_Score, "\n")
+cat("Total P-value:", res$Total_Pvalue, "\n")
+```
+
+### `ppi_subset()`
+
+Subset PPI network by edge score and top-n node degree
+
+This function filters a PPI network in two steps:
+
+Removes edges with a score below score_cutoff.
+(Optional) Keeps only the top n nodes with the highest degree.
+
+Usage:
+```r
+ppi_subset(
+ppi_obj,
+n = NULL,
+score_cutoff = 0.7,
+edge_attr = "score",
+rm_isolates = TRUE
+)
+```
+
+参数解析:
+- `ppi_obj`: An igraph object of PPI network.
+- `n`: Integer. Number of top-degree nodes to keep. If NULL (default), no degree filtering is performed.
+- `score_cutoff`: Numeric. Minimum edge score to keep. Default is 0.7.
+- `edge_attr`: Character. The name of the edge attribute representing confidence score. Default is "score" (keep the same as STRING).
+- `rm_isolates`: Logical. Whether to remove isolated nodes (degree = 0) after edge filtering. Default is TRUE.
+
+使用示例:
+```r
+data(demo_ppi)
+library(igraph)
+ppi.subset <- ppi_subset(demo_ppi, score_cutoff = 0.7)
+str(ppi.subset)
+```
+
+### `radar_plot()`
+
+Plot a radar chart for node centrality profile
+
+This function draws a radar-style polygon plot for a single node,
+showing its values on multiple centrality metrics.
+
+Usage:
+```r
+radar_plot(
+profile_df,
+category_col = "metric",
+value_col = "value",
+fill_color = "#B6B0D4",
+line_color = "#6D65A6",
+title = NULL
+)
+```
+
+参数解析:
+- `profile_df`: A data frame containing at least one column of metric
+names and one column of numeric values.
+- `category_col`: Character string; column name in profile_df
+for metric labels. Defaults to "metric".
+- `value_col`: Character string; column name in profile_df
+for metric values (usually scaled to [0, 1]). Defaults to "value".
+- `fill_color`: Polygon fill color. "#A3BEDD", "#A7CBA9", and "#D59390" are recommended.
+- `line_color`: Polygon border color.
+- `title`: Character; plot title. Default is NULL.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+radar_plot(
+profile_df,
+category_col = "metric",
+value_col = "value",
+fill_color = "#B6B0D4",
+line_color = "#6D65A6",
+title = NULL
+)
+```
+
+### `rank_ppi_nodes()`
+
+Rank PPI nodes by integrated network centrality
+
+Rank PPI nodes by integrated network centrality
+
+Usage:
+```r
+rank_ppi_nodes(
+g,
+metrics = c("degree", "betweenness", "closeness", "eccentricity", "radiality",
+"Stress", "MCC", "MNC", "DMNC", "BN", "EPC"),
+weights = NULL,
+use_weight = TRUE,
+na_rm = TRUE
+)
+```
+
+参数解析:
+- `g`: An igraph object that has already been processed by compute_nodeinfo() or have added node metrics manually.
+- `metrics`: Character vector; which vertex attributes to use for scoring. Defaults are the same as Cytohubba.
+- `weights`: Numeric vector of the same length as metrics; relative weights for each metric. If NULL (default), all metrics are equally weighted.
+- `use_weight`: Logical; whether use weighted metrics(beweenness and closeness) instead. Default is TRUE.
+- `na_rm`: Logical; if TRUE, NAs are ignored in normalization (set to 0.5).
+
+使用示例:
+```r
+data(demo_ppi)
+library(igraph)
+ppi <- compute_nodeinfo(demo_ppi)
+rank_res <- rank_ppi_nodes(ppi)
+
+# update igraph object and extract rank info
+ppi <- rank_res[[1]]
+rank_df <- rank_res[[2]]
+print(rank_df)
+```
+
+### `run_fastgreedy()`
+
+Compute Fast Greedy Clustering for PPI Network
+
+This function performs fast greedy modularity optimization on an igraph object.
+It is suitable for detecting communities in undirected PPI networks.
+
+Usage:
+```r
+run_fastgreedy(g, weights = NULL)
+```
+
+参数解析:
+- `g`: An igraph object.
+- `weights`: Numeric vector, character, NULL, or NA. Edge weights to use for
+clustering. If NULL (default), the function attempts to use the weight
+edge attribute first, then the score edge attribute. If a character
+value is supplied, it is treated as the edge attribute name. Set to NA to
+perform unweighted clustering.
+
+使用示例:
+```r
+data(demo_ppi)
+library(igraph)
+ppi <- run_fastgreedy(demo_ppi)
+head(V(ppi)$fastgreedy_cluster)
+```
+
+### `run_louvain()`
+
+Compute Louvain Clustering for PPI Network
+
+This function performs Louvain clustering (multi-level modularity optimization)
+on an igraph object. It is suitable for detecting larger, macro-scale functional
+modules in PPI networks.
+
+Usage:
+```r
+run_louvain(g, resolution = 1, weights = NULL)
+```
+
+参数解析:
+- `g`: An igraph object.
+- `resolution`: Numeric. The resolution parameter controls the granularity of clusters. Default is 1.0 (standard modularity).
+- `weights`: Numeric vector or NULL. Edge weights to use for clustering.
+If NULL (default), the function attempts to use the 'weight' or 'score' edge attribute.
+Set to NA to perform unweighted clustering.
+
+使用示例:
+```r
+data(demo_ppi)
+library(igraph)
+ppi <- run_louvain(demo_ppi, resolution = 1)
+head(V(ppi)$louvain_cluster)
+```
+
+### `run_MCL()`
+
+Perform Markov Clustering (MCL) on a Graph
+
+This function implements the Markov Clustering (MCL) algorithm for detecting
+communities (clusters) in a graph. MCL simulates random walks within the graph
+by alternating between two operations: expansion and inflation. It is particularly
+efficient for biological networks.
+
+Usage:
+```r
+run_MCL(g, inflation = 2.5, max_iter = 100, pruning = 1e-05, allow1 = FALSE)
+```
+
+参数解析:
+- `g`: An igraph object. The graph to be clustered. It can be directed or undirected.
+- `inflation`: Numeric. Controls cluster granularity. Higher values (e.g., > 2) yield smaller, tighter clusters; lower values yield larger clusters. Default is 2.5.
+- `max_iter`: Integer. The maximum number of iterations to perform if convergence is not reached. Default is 100.
+- `pruning`: Numeric. A threshold for pruning small values in the matrix to zero.
+This preserves the sparsity of the matrix and significantly speeds up computation
+while saving memory. Default is 1e-5.
+- `allow1`: Logical. If TRUE, clusters with only 1 node are kept as unique clusters. If FALSE,
+cluster of size 1 are interpreted as background noise and grouped in one cluster. Default is FALSE.
+
+使用示例:
+```r
+library(igraph)
+g <- make_graph("Zachary")
+g <- run_MCL(g, inflation = 2.5)
+print(head(V(g)$MCL_cluster))
+
+# Visualize
+plot(g,
+vertex.color = V(g)$MCL_cluster,
+vertex.size = 15,
+vertex.label = V(g)$name)
+```
+
+### `run_mcode()`
+
+Molecular Complex Detection (MCODE) method for identifying PPI clusters.
+
+Molecular Complex Detection (MCODE) method for identifying PPI clusters.
+
+Usage:
+```r
+run_mcode(
+g,
+vwp = 0.2,
+degree_cutoff = 2,
+k_core_threshold = 2,
+haircut = TRUE,
+fluff = FALSE,
+fdt = 0.1,
+loops = FALSE,
+max_depth = 100
+)
+
+runMCODE(...)
+```
+
+参数解析:
+- `g`: An igraph object (PPI network).
+- `vwp`: Numeric. Node Score Cutoff (Vertex Weight Percentage). Default 0.2.
+- `degree_cutoff`: Numeric. Nodes with degree < cutoff will get a score of 0. Default 2.
+- `k_core_threshold`: Numeric. Filters out clusters that do not contain a k-core of at least this level. Default 2.
+- `haircut`: Logical. Whether to prune singly-connected nodes. Default TRUE.
+- `fluff`: Logical. Whether to expand cluster by adding dense neighbors. Default FALSE.
+- `fdt`: Numeric. Fluff Node Density Cutoff. Used if fluff=TRUE. Default 0.1.
+- `loops`: Logical. Whether to include self-loops in scoring. Default FALSE.
+- `max_depth`: Numeric. Maximum recursion depth for cluster finding (to prevent stack overflow on huge networks). Default 100.
+- `...`: Additional arguments passed to run_mcode when using the deprecated alias runMCODE.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- run_mcode(demo_ppi, max_depth = 100)
+str(ppi)
+```
+
+## Artifact management
+
+### `artifact_exists()`
+
+Check if artifact exists
+
+Check if artifact exists
+
+Usage:
+```r
+artifact_exists(artifact_id)
+```
+
+参数解析:
+- `artifact_id`: Character. The artifact identifier.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+artifact_exists(artifact_id)
+```
+
+### `clear_tcm_artifacts()`
+
+Clear all artifacts from registry
+
+Removes all stored artifacts. Use with caution.
+
+Usage:
+```r
+clear_tcm_artifacts()
+```
+
+参数解析:
+- No user-facing parameters; call exactly as shown in Usage.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+clear_tcm_artifacts()
+```
+
+### `list_tcm_artifacts()`
+
+List all TCM artifacts in the registry
+
+Returns a data.frame summarizing all stored artifacts.
+
+Usage:
+```r
+list_tcm_artifacts()
+```
+
+参数解析:
+- No user-facing parameters; call exactly as shown in Usage.
+
+使用示例:
+```r
+list_tcm_artifacts()
+```
+
+### `load_tcm_artifact()`
+
+Load a TCM artifact from the registry
+
+Retrieves the actual R object by its artifact_id.
+
+Usage:
+```r
+load_tcm_artifact(artifact_id)
+```
+
+参数解析:
+- `artifact_id`: Character. The artifact identifier.
+
+使用示例:
+```r
+enrich_obj <- load_tcm_artifact("enrich_001")
+```
+
+### `save_tcm_artifact()`
+
+Save a TCM artifact to the registry
+
+Stores a complex R object (igraph, enrichResult, data.frame, etc.) and
+returns a lightweight handle that can be passed to the LLM.
+
+Usage:
+```r
+save_tcm_artifact(
+object,
+artifact_type,
+artifact_id = NULL,
+summary = NULL,
+provenance = NULL
+)
+```
+
+参数解析:
+- `object`: The R object to store.
+- `artifact_type`: Character. Type label, e.g. "enrichment_result",
+"herb_graph", "ppi_graph", "ranking_table".
+- `artifact_id`: Character or NULL. If NULL, auto-generated.
+- `summary`: Character or NULL. Human-readable summary for LLM context.
+- `provenance`: List or NULL. Metadata about how this artifact was created.
+
+使用示例:
+```r
+# Save an enrichment result
+enrich_res <- herb_enricher(genes = my_genes)
+artifact <- save_tcm_artifact(
+object = enrich_res,
+artifact_type = "enrichment_result",
+summary = "Herb enrichment on 126 genes; 14 terms passed cutoff."
+)
+# artifact$artifact_id can be passed to next tool call
+```
+
+### `summarize_tcm_artifact()`
+
+Summarize a TCM artifact for LLM context
+
+Generates a concise text summary suitable for passing to the LLM.
+
+Usage:
+```r
+summarize_tcm_artifact(artifact_id, max_lines = 5L)
+```
+
+参数解析:
+- `artifact_id`: Character. The artifact identifier.
+- `max_lines`: Integer. Maximum lines for preview tables.
+
+使用示例:
+```r
+summarize_tcm_artifact("enrich_001")
+```
+
+## Molecule annotation and docking support
+
+### `compound_similarity()`
+
+Similarity search (Tanimoto) on PubChem
+
+Similarity search (Tanimoto) on PubChem
+
+Usage:
+```r
+compound_similarity(
+query,
+from = c("smiles", "cid", "inchikey", "name"),
+threshold = 90,
+topn = 10,
+fetch_factor = 3,
+compute_score = TRUE,
+...
+)
+```
+
+参数解析:
+- `query`: identifier (CID/SMILES/InChIKey/Name)
+- `from`: one of c("cid","smiles","inchikey","name")
+- `threshold`: integer 0–100 (percent), e.g. 90
+- `topn`: max records to return. Default 10.
+- `fetch_factor`: The multiplier for overfetching candidate compounds (default = 5).
+- `compute_score`: Logical. If TRUE, use rcdk to compute Tanimoto score locally. Set to FALSE if rJava causes crashes.
+- `...`: Additional arguments passed to internal helper functions.
+
+使用示例:
+```r
+sim_hits <- compound_similarity(
+query = "996",
+from = "cid",
+compute_score = TRUE)
+```
+
+### `convert_structure()`
+
+Convert molecular structure files between formats
+
+Convert molecular structure format via Open Babel
+
+Usage:
+```r
+convert_structure(
+input_file,
+output_file = NULL,
+input_type = NULL,
+output_type = "pdb",
+add_hydrogens = FALSE,
+gen3d = FALSE,
+overwrite = FALSE,
+quiet = FALSE
+)
+```
+
+参数解析:
+- `input_file`: Path to input structure file.
+- `output_file`: Output path, or NULL to auto-derive.
+- `input_type`: Input format (e.g. "sdf"), or NULL
+to detect from extension.
+- `output_type`: Output format. Default "pdb".
+- `add_hydrogens`: Add hydrogens? Default FALSE.
+- `gen3d`: Generate 3D coordinates? Default FALSE.
+- `overwrite`: Overwrite existing file? Default FALSE.
+- `quiet`: Suppress messages? Default FALSE.
+
+使用示例:
+```r
+sdf <- download_ligand_structure(2244, destdir = tempdir())
+convert_structure(sdf)                          # SDF -> PDB
+convert_structure(sdf, output_type = "mol2")    # SDF -> MOL2
+```
+
+### `download_ligand_structure()`
+
+Download ligand SDF from PubChem
+
+Download ligand SDF from PubChem
+
+Usage:
+```r
+download_ligand_structure(
+cid,
+type = c("auto", "3d", "2d"),
+destdir = ".",
+filename = NULL,
+overwrite = FALSE,
+quiet = FALSE
+)
+```
+
+参数解析:
+- `cid`: PubChem Compound ID.
+- `type`: "auto" (default, 3D then 2D), "3d", or "2d".
+- `destdir`: Save directory. Default ".".
+- `filename`: Output name, or NULL for auto-naming.
+- `overwrite`: Overwrite existing file? Default FALSE.
+- `quiet`: Suppress messages? Default FALSE.
+
+使用示例:
+```r
+download_ligand_structure(2244)
+download_ligand_structure(2244, type = "3d", destdir = tempdir())
+```
+
+### `download_receptor_structure()`
+
+Download receptor structure from RCSB PDB
+
+Download receptor structure from RCSB PDB
+
+Usage:
+```r
+download_receptor_structure(
+pdb_id,
+format = c("pdb", "cif"),
+destdir = ".",
+filename = NULL,
+overwrite = FALSE,
+quiet = FALSE
+)
+```
+
+参数解析:
+- `pdb_id`: 4-character PDB ID (e.g. "4hhb"). Case-insensitive.
+- `format`: "pdb" (default) or "cif".
+- `destdir`: Save directory. Default ".".
+- `filename`: Output name, or NULL for auto-naming.
+- `overwrite`: Overwrite existing file? Default FALSE.
+- `quiet`: Suppress messages? Default FALSE.
+
+使用示例:
+```r
+download_receptor_structure("4hhb")
+download_receptor_structure("4hhb", format = "cif", destdir = tempdir())
+```
+
+### `getcid()`
+
+Get CID for compounds from PubChem
+
+Retrieve PubChem Compound IDs (CIDs) for a vector of compound names.
+This function wraps webchem::get_cid() with built-in rate limiting
+(≤5 requests per second as recommended by PubChem).
+
+Usage:
+```r
+getcid(
+compound,
+from = c("name", "smiles", "inchi"),
+match = c("first", "best", "all"),
+pause = 0.25,
+quiet = TRUE,
+...
+)
+```
+
+参数解析:
+- `compound`: A character vector of compound names.
+- `from`: Source type for lookup, e.g. "name", "smiles", "inchi".
+- `match`: Match mode, one of "first", "best", or "all".
+- `pause`: Pause time (in seconds) between requests. Default is 0.25s (≈4 req/s).
+- `quiet`: Logical, whether to suppress messages. Default TRUE.
+- `...`: Additional arguments passed to internal helper functions.
+
+使用示例:
+```r
+res_smiles <- getcid("CCO", from = "smiles")
+print(res_smiles)
+```
+
+### `getprops()`
+
+get properties for compounds from PubChem
+
+get properties for compounds from PubChem
+
+Usage:
+```r
+getprops(
+cid,
+properties = c("MolecularFormula", "MolecularWeight", "IUPACName", "CanonicalSMILES",
+"InChIKey", "XLogP"),
+...
+)
+```
+
+参数解析:
+- `cid`: Integer/numeric/character vector of PubChem CIDs.
+- `properties`: Character vector of PubChem property keys to request.
+- `...`: Additional arguments passed to internal helper functions.
+
+使用示例:
+```r
+herbs <- c("灵芝")
+lz <- search_herb(herb = herbs, type = "Herb_cn_name")
+lz_mol <- sample(unique(lz$molecule), 5, replace = FALSE)
+lz_mol_cid <- resolve_cid(lz_mol, from = "name")
+props <- getprops(lz_mol_cid)
+print(props)
+```
+
+### `ggdock()`
+
+Plot molecule–target docking affinity heatmaps
+
+Plot molecule–target docking affinity heatmaps
+
+Usage:
+```r
+ggdock(
+dock_data,
+order = NULL,
+type = "dot",
+point_size = 8,
+base_size = 12,
+angle = 50,
+hjust = 1,
+vjust = 1,
+palette = "ggthemes::Orange-Blue-White Diverging",
+label = FALSE,
+label_digits = 2,
+label_size = 3,
+label_color = "black",
+label_family = "sans",
+label_fontface = "plain",
+...
+)
+```
+
+参数解析:
+- `dock_data`: A numeric matrix or data frame.
+- `order`: Reordering method for factor levels (optional).
+- `type`: Type of visualization, either "dot" or "tile".
+- `point_size`: Numeric. Point size used in dot plots. Default is 6.
+- `base_size`: Numeric. Base font size for the theme. Default is 12.
+- `angle`: Numeric. Rotation angle for x-axis text labels. Default is 50.
+- `hjust`: Numeric. Horizontal justification for x-axis labels.
+- `vjust`: Numeric. Vertical justification for x-axis labels.
+- `palette`: Character. Name of the continuous color palette to use. Default is "ggthemes::Orange-Blue-White Diverging".
+- `label`: Logical. If TRUE, print affinity numbers on the plot. Default FALSE.
+- `label_digits`: Integer. Number of digits to show for the affinity text. Default 2.
+- `label_size`: Numeric. Text size for affinity labels. Default 3.5.
+- `label_color`: Character. Text color for affinity labels. Default "black".
+- `label_family`: Character. Font family for labels (e.g., "sans", "Times"). Default "sans".
+- `label_fontface`: Character. Font face for labels: "plain", "bold", "italic", "bold.italic". Default "plain".
+- `...`: Additional parameters passed to geom_point() or geom_tile().
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+ggdock(
+dock_data,
+order = NULL,
+type = "dot",
+point_size = 8,
+base_size = 12,
+angle = 50,
+hjust = 1,
+vjust = 1,
+palette = "ggthemes::Orange-Blue-White Diverging",
+label = FALSE,
+label_digits = 2,
+label_size = 3,
+label_color = "black",
+label_family = "sans",
+label_fontface = "plain",
+...
+)
+```
+
+### `resolve_cid()`
+
+Resolve arbitrary identifiers to PubChem CIDs
+
+Resolve user-provided identifiers (CID/SMILES/InChI/InChIKey/Name)
+to PubChem Compound IDs (CIDs). For structural inputs (SMILES/InChI),
+it prefers POSTing the value in the request body to avoid URL length/encoding issues,
+and falls back to a GET path-style endpoint if needed.
+
+Usage:
+```r
+resolve_cid(x, from = c("cid", "smiles", "inchi", "inchikey", "name"))
+```
+
+参数解析:
+- `x`: Character vector. Values can be CIDs, SMILES, InChI, InChIKey, or names.
+- `from`: One of c("cid","smiles","inchi","inchikey","name").
+
+使用示例:
+```r
+herbs <- c("灵芝")
+lz <- search_herb(herb = herbs, type = "Herb_cn_name")
+lz_mol <- sample(unique(lz$molecule), 5, replace = FALSE)
+lz_mol_cid <- resolve_cid(lz_mol, from = "name")
+print(lz_mol_cid)
+```
+
+### `sdf_to_pdb()`
+
+Convert SDF file to PDB format
+
+Backward-compatible wrapper around convert_structure for
+the common SDF-to-PDB conversion workflow.
+
+Usage:
+```r
+sdf_to_pdb(
+sdf_file,
+pdb_file = NULL,
+add_hydrogens = TRUE,
+gen3d = FALSE,
+overwrite = FALSE,
+quiet = FALSE
+)
+```
+
+参数解析:
+- `sdf_file`: Path to input SDF file.
+- `pdb_file`: Output PDB path, or NULL to auto-derive.
+- `add_hydrogens`: Add hydrogens? Default TRUE.
+- `gen3d`: Generate 3D coordinates? Default FALSE.
+- `overwrite`: Overwrite existing file? Default FALSE.
+- `quiet`: Suppress messages? Default FALSE.
+
+使用示例:
+```r
+sdf <- download_ligand_structure(2244, destdir = tempdir())
+pdb <- sdf_to_pdb(sdf)
+```
+
+## AI and agent layer
+
+### `create_tcm_agent()`
+
+Create a generic aisdk agent
+
+A thin wrapper around aisdk::create_agent().
+Unlike create_tcm_task_agent, this creates a generic agent
+without TCM-specific tools or system prompt.
+Pass the result to run_tcm_agent to call it.
+
+Usage:
+```r
+create_tcm_agent(name, description, system_prompt)
+```
+
+参数解析:
+- `name`: Character. A short identifier for the agent.
+- `description`: Character. One-line description of the agent's role.
+- `system_prompt`: Character. The system prompt defining agent behaviour.
+
+使用示例:
+```r
+bio_agent <- create_tcm_agent(
+name = "BioInterpreter",
+description = "Bioinformatics result interpreter",
+system_prompt = "You are a bioinformatics expert. Explain results
+concisely in 3 sentences for a research report."
+)
+```
+
+### `create_tcm_ml_list()`
+
+Assemble individually fitted ML models into a tcm_ml_list
+
+Assemble individually fitted ML models into a tcm_ml_list
+
+Usage:
+```r
+create_tcm_ml_list(...)
+```
+
+参数解析:
+- `...`: Named or unnamed tcm_ml objects. Names become the method labels used in downstream plots. At least one object must be supplied.
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res_lasso <- ml_lasso(ml_data)
+res_rf <- ml_rf(ml_data)
+res_svm <- ml_svm_rfe(ml_data)
+
+## assemble into a tcm_ml_list
+ml_list <- create_tcm_ml_list(
+lasso   = res_lasso,
+rf      = res_rf,
+svm_rfe = res_svm)
+```
+
+### `create_tcm_task_agent()`
+
+Create a TCM task agent
+
+Creates an aisdk agent configured for TCM network pharmacology analysis.
+The agent can call TCMDATA tools natively.
+
+Usage:
+```r
+create_tcm_task_agent(tools = NULL, system_prompt = NULL, skills = NULL)
+```
+
+参数解析:
+- `tools`: List of Tool objects. If NULL, uses default tools from
+create_tcm_tools.
+- `system_prompt`: Character. Custom system prompt. If NULL, uses default.
+- `skills`: Character vector of skill directories. If NULL, uses
+the active TCMDATA skill directory plus aisdk's
+skill-creator skill (if available). Use character(0) to
+disable skills entirely.
+
+使用示例:
+```r
+agent <- create_tcm_task_agent()
+result <- run_tcm_task(agent, "Search targets of Astragalus")
+```
+
+### `create_tcm_tools()`
+
+Create all TCM analysis tools
+
+Returns a list of aisdk Tool objects that wrap TCMDATA analysis functions.
+These tools can be passed to an aisdk agent for native tool calling.
+
+Usage:
+```r
+create_tcm_tools(task_type = NULL, tool_names = NULL)
+```
+
+参数解析:
+- `task_type`: Character or NULL. If provided, only returns tools relevant
+to this task type (for example, "enrichment", "ppi_analysis",
+or "ml_screening"). If NULL, returns all tools.
+- `tool_names`: Character vector or NULL. If provided, overrides task_type
+and returns only tools whose names are in this vector. Useful when the
+router merges tools from multiple matched task types.
+
+使用示例:
+```r
+tools <- create_tcm_tools()
+tools <- create_tcm_tools(task_type = "enrichment")
+```
+
+### `create_tcm_workflow()`
+
+Create a TCM analysis workflow
+
+Defines a multi-step analysis workflow that can be executed automatically.
+
+Usage:
+```r
+create_tcm_workflow(name, steps)
+```
+
+参数解析:
+- `name`: Character. Workflow name.
+- `steps`: List of step definitions, each with 'tool' and 'params'.
+
+使用示例:
+```r
+workflow <- create_tcm_workflow(
+name = "herb_to_hub",
+steps = list(
+list(tool = "search_herb_records",
+params = list(herb = "{{herb}}", type = "Herb_pinyin_name")),
+list(tool = "run_herb_enrichment",
+params = list(genes = "{{from_previous}}")),
+list(tool = "interpret_artifact",
+params = list(artifact_id = "{{from_previous}}"))
+)
+)
+run_tcm_workflow(workflow, herb = "Astragalus")
+```
+
+### `make_tcm_function()`
+
+Create a reusable AI function from an instruction
+
+A function factory: supply an instruction (system prompt) once, get back a
+plain R function. The returned function accepts a query string and behaves
+like any ordinary R function -- it works directly in sapply(),
+purrr::map(), mutate(), and other vectorised workflows.
+
+Usage:
+```r
+make_tcm_function(instruction, name = "CustomFn")
+```
+
+参数解析:
+- `instruction`: Character. The system prompt that defines the function's
+behaviour (its "role" and task description).
+- `name`: Character. A short identifier used for the underlying agent.
+Useful for debugging. Default "CustomFn".
+
+使用示例:
+```r
+explain_pathway <- make_tcm_function(
+"You are an MSigDB/KEGG pathway expert. Explain the biological
+function of the pathway in 2 sentences for a research report."
+)
+explain_pathway("HALLMARK_INFLAMMATORY_RESPONSE")
+
+pathways <- c("HALLMARK_E2F_TARGETS", "HALLMARK_OXIDATIVE_PHOSPHORYLATION")
+explanations <- sapply(pathways, explain_pathway)
+```
+
+### `route_tcm_task()`
+
+Route a task to the appropriate tool set
+
+Analyzes the user's task description and determines which tools should be
+made available to the agent. Uses rule-based routing first, then optionally
+falls back to LLM routing for ambiguous cases.
+
+Usage:
+```r
+route_tcm_task(task, use_llm = FALSE, model = NULL)
+```
+
+参数解析:
+- `task`: Character. The user's task description.
+- `use_llm`: Logical. Whether to use LLM for ambiguous routing.
+- `model`: Model object for LLM routing when use_llm = TRUE.
+
+使用示例:
+```r
+route_tcm_task("Run GO enrichment on the target genes")
+route_tcm_task("Retrieve a PPI network and rank hub genes")
+```
+
+### `run_tcm_agent()`
+
+Run an agent as a plain function
+
+Wraps agent$run() so the agent behaves like an ordinary R function.
+Prints the response via cat() and returns it invisibly.
+
+Usage:
+```r
+run_tcm_agent(agent, query, model = NULL, verbose = TRUE)
+```
+
+参数解析:
+- `agent`: An agent object from create_tcm_agent.
+- `query`: Character. The query or task to send to the agent.
+- `model`: A model identifier, LanguageModelV1 object, or NULL (uses the
+package-wide default set via aisdk::set_model()).
+- `verbose`: Logical. If TRUE (default), print the response to the
+console. Set FALSE for programmatic / batch use.
+
+使用示例:
+```r
+bio_agent <- create_tcm_agent(
+name = "BioInterpreter",
+description = "Bioinformatics result interpreter",
+system_prompt = "You are a bioinformatics expert."
+)
+run_tcm_agent(bio_agent, "Explain HALLMARK_E2F_TARGETS")
+```
+
+### `run_tcm_task()`
+
+Run a task with a TCM agent
+
+Executes a natural language task using the provided agent.
+
+Usage:
+```r
+run_tcm_task(agent, task, model = NULL, verbose = TRUE)
+```
+
+参数解析:
+- `agent`: An Agent object from create_tcm_task_agent.
+- `task`: Character. The task description in natural language.
+- `model`: Model object or NULL (uses package default).
+- `verbose`: Logical. Print progress and results (default TRUE).
+
+使用示例:
+```r
+agent <- create_tcm_task_agent()
+result <- run_tcm_task(agent, "Run herb enrichment on Astragalus targets")
+```
+
+### `run_tcm_workflow()`
+
+Run a TCM analysis workflow
+
+Executes a predefined workflow step by step.
+
+Usage:
+```r
+run_tcm_workflow(workflow, ..., verbose = TRUE)
+```
+
+参数解析:
+- `workflow`: A workflow object from create_tcm_workflow.
+- `...`: Named parameters to substitute into step definitions.
+- `verbose`: Logical. Print progress (default TRUE).
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+run_tcm_workflow(workflow, ..., verbose = TRUE)
+```
+
+### `tcm_agent()`
+
+One-step TCM task execution
+
+The main entry point for natural language TCM analysis. Automatically
+routes the task, creates appropriate agent, and executes the task.
+
+Usage:
+```r
+tcm_agent(task, model = NULL, verbose = TRUE, use_router = TRUE)
+```
+
+参数解析:
+- `task`: Character. Natural language task description.
+- `model`: Model object or NULL (uses package default).
+- `verbose`: Logical. Print progress and results (default TRUE).
+- `use_router`: Logical. Use task router to select tools (default TRUE).
+
+使用示例:
+```r
+# Basic usage
+tcm_agent("Search targets of Astragalus")
+
+# Herb enrichment workflow
+tcm_agent("Run herb enrichment on Astragalus targets and find top hub genes")
+
+# PPI analysis
+tcm_agent("Analyse PPI network for diabetes-related genes and find hub genes")
+
+# Interpretation
+tcm_agent("Interpret the previous enrichment result")
+```
+
+### `tcm_aisdk_skill()`
+
+Get path to a bundled aisdk skill
+
+Returns the absolute path to a skill bundled with the aisdk
+package, such as "skill-creator". This is useful when combining
+TCMDATA's own skills with upstream aisdk skills without copying them into
+the TCMDATA package.
+
+Usage:
+```r
+tcm_aisdk_skill(name = "skill-creator")
+```
+
+参数解析:
+- `name`: Character. Skill name in aisdk/inst/skills.
+Default "skill-creator".
+
+使用示例:
+```r
+skill_creator <- tcm_aisdk_skill()
+agent <- create_tcm_task_agent(
+skills = c(tcm_skill_dir(), skill_creator)
+)
+```
+
+### `tcm_chat()`
+
+Interactive TCM analysis chat
+
+Starts a rich interactive chat session for multi-turn TCM analysis
+conversations in the terminal. Each exchange is formatted with clear
+visual structure including routing information, tool call logs, artifact
+updates, and the agent response.
+
+Usage:
+```r
+tcm_chat(model = NULL, verbose = TRUE, stream = TRUE, skills = NULL)
+```
+
+参数解析:
+- `model`: Model object or NULL.
+- `verbose`: Logical. Print agent responses (default TRUE).
+- `stream`: Logical. Enable streaming output (default TRUE). Toggle
+at runtime with the /stream command.
+- `skills`: Character vector of skill directories to load for the chat
+session. Default NULL disables aisdk skills for chat stability and
+uses TCMDATA's built-in tool-oriented system prompt. Pass explicit skill
+paths, for example c(tcm_skill_dir(), tcm_aisdk_skill()), to enable
+skill loading.
+
+使用示例:
+```r
+tcm_chat()
+# With streaming disabled
+tcm_chat(stream = FALSE)
+# Add aisdk's skill-creator alongside TCMDATA skills
+tcm_chat(skills = c(tcm_skill_dir(), tcm_aisdk_skill()))
+```
+
+### `tcm_config()`
+
+Write AI provider credentials to .env
+
+Saves TCM_PROVIDER, TCM_API_KEY, TCM_MODEL, and
+optionally TCM_BASE_URL to a .env file. Existing values for
+these four keys are overwritten; all other lines are preserved.
+
+Usage:
+```r
+tcm_config(provider, api_key, model, base_url = NULL, path = ".env")
+```
+
+参数解析:
+- `provider`: Character. Provider name (see Details).
+- `api_key`: Character. Your API key.
+- `model`: Character. Model name, e.g. "gpt-4o-mini",
+"claude-3-5-haiku-20241022", "gemini-2.0-flash".
+- `base_url`: Character or NULL. Override the default API endpoint.
+Required for proxies or self-hosted endpoints.
+- `path`: Character. Path to the .env file. Default ".env".
+
+使用示例:
+```r
+tcm_config("openai",    "sk-xxx",     "gpt-4o-mini")
+tcm_config("anthropic", "sk-ant-xxx", "claude-3-5-haiku-20241022")
+tcm_config("gemini",    "AIza-xxx",   "gemini-2.0-flash")
+tcm_config("deepseek",  "sk-xxx",     "deepseek-chat")
+tcm_config("openai",    "sk-xxx",     "gpt-5-minimal",
+base_url = "https://www.packyapi.com/v1")
+```
+
+### `tcm_field_array()`
+
+Build a custom output schema for tcm_interpret_schema()
+
+A family of thin wrappers around aisdk::z_object() and the
+associated field constructors. These functions let you define structured
+output contracts without writing aisdk:: anywhere in your code.
+
+Usage:
+```r
+tcm_schema(...)
+
+tcm_field_string(description = "")
+
+tcm_field_number(description = "")
+
+tcm_field_boolean(description = "")
+
+tcm_field_array(description = "")
+
+tcm_field_enum(choices, description = "")
+```
+
+参数解析:
+- `...`: Named field definitions created with tcm_field_*().
+- `description`: Character. Guidance for the model about this field.
+Default "" (no description).
+- `choices`: Character vector of allowed values (for tcm_field_enum
+only).
+
+使用示例:
+```r
+my_schema <- tcm_schema(
+summary     = tcm_field_string("2-3 sentence overview"),
+mechanism   = tcm_field_string("Key molecular mechanism"),
+key_targets = tcm_field_array("Top gene or protein targets"),
+score       = tcm_field_number("Confidence score 0-1"),
+is_tcm      = tcm_field_boolean("Whether TCM herbs are involved"),
+confidence  = tcm_field_enum(c("high", "medium", "low"))
+)
+
+res <- tcm_interpret_schema(enrich_res, schema = my_schema,
+language = "zh")
+res$output$summary
+res$output$key_targets   # character vector
+res$output$confidence    # one of "high" / "medium" / "low"
+```
+
+### `tcm_field_boolean()`
+
+Build a custom output schema for tcm_interpret_schema()
+
+A family of thin wrappers around aisdk::z_object() and the
+associated field constructors. These functions let you define structured
+output contracts without writing aisdk:: anywhere in your code.
+
+Usage:
+```r
+tcm_schema(...)
+
+tcm_field_string(description = "")
+
+tcm_field_number(description = "")
+
+tcm_field_boolean(description = "")
+
+tcm_field_array(description = "")
+
+tcm_field_enum(choices, description = "")
+```
+
+参数解析:
+- `...`: Named field definitions created with tcm_field_*().
+- `description`: Character. Guidance for the model about this field.
+Default "" (no description).
+- `choices`: Character vector of allowed values (for tcm_field_enum
+only).
+
+使用示例:
+```r
+my_schema <- tcm_schema(
+summary     = tcm_field_string("2-3 sentence overview"),
+mechanism   = tcm_field_string("Key molecular mechanism"),
+key_targets = tcm_field_array("Top gene or protein targets"),
+score       = tcm_field_number("Confidence score 0-1"),
+is_tcm      = tcm_field_boolean("Whether TCM herbs are involved"),
+confidence  = tcm_field_enum(c("high", "medium", "low"))
+)
+
+res <- tcm_interpret_schema(enrich_res, schema = my_schema,
+language = "zh")
+res$output$summary
+res$output$key_targets   # character vector
+res$output$confidence    # one of "high" / "medium" / "low"
+```
+
+### `tcm_field_enum()`
+
+Build a custom output schema for tcm_interpret_schema()
+
+A family of thin wrappers around aisdk::z_object() and the
+associated field constructors. These functions let you define structured
+output contracts without writing aisdk:: anywhere in your code.
+
+Usage:
+```r
+tcm_schema(...)
+
+tcm_field_string(description = "")
+
+tcm_field_number(description = "")
+
+tcm_field_boolean(description = "")
+
+tcm_field_array(description = "")
+
+tcm_field_enum(choices, description = "")
+```
+
+参数解析:
+- `...`: Named field definitions created with tcm_field_*().
+- `description`: Character. Guidance for the model about this field.
+Default "" (no description).
+- `choices`: Character vector of allowed values (for tcm_field_enum
+only).
+
+使用示例:
+```r
+my_schema <- tcm_schema(
+summary     = tcm_field_string("2-3 sentence overview"),
+mechanism   = tcm_field_string("Key molecular mechanism"),
+key_targets = tcm_field_array("Top gene or protein targets"),
+score       = tcm_field_number("Confidence score 0-1"),
+is_tcm      = tcm_field_boolean("Whether TCM herbs are involved"),
+confidence  = tcm_field_enum(c("high", "medium", "low"))
+)
+
+res <- tcm_interpret_schema(enrich_res, schema = my_schema,
+language = "zh")
+res$output$summary
+res$output$key_targets   # character vector
+res$output$confidence    # one of "high" / "medium" / "low"
+```
+
+### `tcm_field_number()`
+
+Build a custom output schema for tcm_interpret_schema()
+
+A family of thin wrappers around aisdk::z_object() and the
+associated field constructors. These functions let you define structured
+output contracts without writing aisdk:: anywhere in your code.
+
+Usage:
+```r
+tcm_schema(...)
+
+tcm_field_string(description = "")
+
+tcm_field_number(description = "")
+
+tcm_field_boolean(description = "")
+
+tcm_field_array(description = "")
+
+tcm_field_enum(choices, description = "")
+```
+
+参数解析:
+- `...`: Named field definitions created with tcm_field_*().
+- `description`: Character. Guidance for the model about this field.
+Default "" (no description).
+- `choices`: Character vector of allowed values (for tcm_field_enum
+only).
+
+使用示例:
+```r
+my_schema <- tcm_schema(
+summary     = tcm_field_string("2-3 sentence overview"),
+mechanism   = tcm_field_string("Key molecular mechanism"),
+key_targets = tcm_field_array("Top gene or protein targets"),
+score       = tcm_field_number("Confidence score 0-1"),
+is_tcm      = tcm_field_boolean("Whether TCM herbs are involved"),
+confidence  = tcm_field_enum(c("high", "medium", "low"))
+)
+
+res <- tcm_interpret_schema(enrich_res, schema = my_schema,
+language = "zh")
+res$output$summary
+res$output$key_targets   # character vector
+res$output$confidence    # one of "high" / "medium" / "low"
+```
+
+### `tcm_field_string()`
+
+Build a custom output schema for tcm_interpret_schema()
+
+A family of thin wrappers around aisdk::z_object() and the
+associated field constructors. These functions let you define structured
+output contracts without writing aisdk:: anywhere in your code.
+
+Usage:
+```r
+tcm_schema(...)
+
+tcm_field_string(description = "")
+
+tcm_field_number(description = "")
+
+tcm_field_boolean(description = "")
+
+tcm_field_array(description = "")
+
+tcm_field_enum(choices, description = "")
+```
+
+参数解析:
+- `...`: Named field definitions created with tcm_field_*().
+- `description`: Character. Guidance for the model about this field.
+Default "" (no description).
+- `choices`: Character vector of allowed values (for tcm_field_enum
+only).
+
+使用示例:
+```r
+my_schema <- tcm_schema(
+summary     = tcm_field_string("2-3 sentence overview"),
+mechanism   = tcm_field_string("Key molecular mechanism"),
+key_targets = tcm_field_array("Top gene or protein targets"),
+score       = tcm_field_number("Confidence score 0-1"),
+is_tcm      = tcm_field_boolean("Whether TCM herbs are involved"),
+confidence  = tcm_field_enum(c("high", "medium", "low"))
+)
+
+res <- tcm_interpret_schema(enrich_res, schema = my_schema,
+language = "zh")
+res$output$summary
+res$output$key_targets   # character vector
+res$output$confidence    # one of "high" / "medium" / "low"
+```
+
+### `tcm_init_skills()`
+
+Initialize a local skills directory
+
+Copies all bundled skills from the TCMDATA package to a local directory.
+Once initialized, the agent will use the local directory instead of the
+package defaults, allowing full customization.
+
+Usage:
+```r
+tcm_init_skills(path = "tcm_skills", overwrite = FALSE)
+```
+
+参数解析:
+- `path`: Character. Directory to create. Default "tcm_skills".
+- `overwrite`: Logical. Overwrite existing directory? Default FALSE.
+
+使用示例:
+```r
+# Copy all skills to ./tcm_skills/ for customization
+tcm_init_skills()
+
+# Then edit the preferences:
+# file.edit("tcm_skills/analysis-preferences/SKILL.md")
+
+# Or place new custom skills under tcm_skills/
+# aisdk's skill-creator remains available by default
+```
+
+### `tcm_interpret()`
+
+Interpret analysis results or free text with AI
+
+A unified entry point that dispatches to the appropriate
+interpret_*() function based on the class of x.
+When x is a character string (or vector), it routes to
+an agent-based text interpreter instead.
+
+Usage:
+```r
+tcm_interpret(
+x,
+type = NULL,
+top_n = NULL,
+max_genes = 5L,
+audience = "researcher",
+language = c("zh", "en"),
+role = NULL,
+system = NULL,
+prompt = NULL,
+model = NULL,
+verbose = TRUE
+)
+```
+
+参数解析:
+- `x`: Analysis result object, or a character string / vector
+for free-text interpretation.
+- `type`: Character or NULL. Overrides auto-detection.
+One of "enrichment", "ppi", "table".
+Takes priority over class-based dispatch, so a data.frame
+enrichment table can be forced with type = "enrichment".
+- `top_n`: Integer. Passed to the underlying interpret
+function (ignored for text).
+- `max_genes`: Integer. Max genes shown per term when
+type = "enrichment". Ignored for text, PPI, and generic tables.
+- `audience`: Character. Preset: "researcher",
+"wetlab", "paper". Or any free-text description
+like "clinical doctor, no bioinformatics background".
+- `language`: Character. "zh" or "en".
+Default "zh".
+- `role`: Character or NULL. The AI's identity description. Passed to
+the underlying interpret_*() function. Ignored for free-text
+input and when system is provided.
+- `system`: Character or NULL. Full system prompt override.
+- `prompt`: Character or NULL. Custom user prompt instruction.
+- `model`: Model identifier or NULL.
+- `verbose`: Logical. If TRUE (default), print the response to
+the console. Set FALSE for programmatic / batch use to suppress
+cat() output. Only affects the free-text path; structured results
+are always returned silently and printed via the S3 print method.
+
+使用示例:
+```r
+tcm_interpret(enrich_res)
+tcm_interpret(ppi_graph,
+role = "You are a systems biologist focusing on drug target identification.")
+# Force enrichment path for a plain data.frame enrichment table
+tcm_interpret(enrich_df, type = "enrichment")
+tcm_interpret(my_df, type = "table")
+# Suppress printing for batch use
+results <- tcm_interpret("IL6 logFC=3.2, TNF logFC=2.8", verbose = FALSE)
+```
+
+### `tcm_interpret_schema()`
+
+Interpret analysis results with a user-defined output schema
+
+A low-level entry point that keeps all existing context-compression and
+prompt logic intact, but replaces the fixed output contract with a schema
+supplied by the caller. Useful when you need a different set of fields than
+the default tcm_interpret produces.
+
+Usage:
+```r
+tcm_interpret_schema(
+x,
+schema,
+type = NULL,
+top_n = NULL,
+max_genes = 5L,
+audience = "researcher",
+language = c("zh", "en"),
+role = NULL,
+system = NULL,
+prompt = NULL,
+model = NULL
+)
+```
+
+参数解析:
+- `x`: Analysis result object. Supported: enrichResult,
+enrichment data.frame, igraph, any data.frame.
+- `schema`: An aisdk::z_object() defining the output structure.
+- `type`: Character or NULL. Override auto-detection.
+One of "enrichment", "ppi", "table".
+- `top_n`: Integer. Rows / nodes to include in the compressed context.
+Default 10 for enrichment/ppi, 20 for table.
+- `max_genes`: Integer. Max genes per term (enrichment only). Default 5.
+- `audience`: Character. Passed to the default system prompt builder.
+Ignored when system is provided.
+- `language`: Character. "zh" or "en". Default "zh".
+- `role`: Character or NULL. Replaces the AI identity line in the default
+system prompt. Ignored when system is provided.
+- `system`: Character or NULL. Full system prompt override.
+- `prompt`: Character or NULL. Instruction prepended to the context block.
+Defaults to "Interpret the following <type> data:".
+- `model`: Model identifier or NULL.
+
+使用示例:
+```r
+# Define a custom schema
+my_schema <- aisdk::z_object(
+summary     = aisdk::z_string("Brief overview"),
+mechanism   = aisdk::z_string("Molecular mechanism"),
+key_targets = aisdk::z_array(aisdk::z_string(), "Top targets"),
+confidence  = aisdk::z_enum(c("high", "medium", "low"))
+)
+
+res <- tcm_interpret_schema(
+enrich_res,
+schema   = my_schema,
+language = "zh",
+prompt   = "Focus on anti-inflammatory pathways:"
+)
+
+# Access fields by name
+res$output$summary
+res$output$key_targets   # character vector
+res$output$confidence
+
+print(res)               # shows all fields generically
+```
+
+### `tcm_reset_skills()`
+
+Reset skills to package defaults
+
+Clears the user skills directory setting so the agent uses the bundled
+package skills again.
+
+Usage:
+```r
+tcm_reset_skills()
+```
+
+参数解析:
+- No user-facing parameters; call exactly as shown in Usage.
+
+使用示例:
+```r
+tcm_reset_skills()
+```
+
+### `tcm_sankey()`
+
+TCM Sankey Plot for herb-molecule-target
+
+TCM Sankey Plot for herb-molecule-target
+
+Usage:
+```r
+tcm_sankey(
+data,
+axis_order = c("herb", "molecule", "target"),
+herb_cols = c("#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b",
+"#e377c2", "#7f7f7f"),
+mol_cols = c("#bcbd22", "#17becf", "#aec7e8", "#ffbb78", "#98df8a", "#ff9896",
+"#c5b0d5", "#E41A1C", "#377EB8"),
+target_cols = c("#c49c94", "#f7b6d2", "#dbdb8d", "#c7e9c0", "#f4cae4", "#e6f598",
+"#ffeda0", "#BB5234", "#BB7813", "#FF6158"),
+plot_font = "sans",
+font_face = "plain",
+target_fontface = "italic",
+font_size = 3.6,
+width = 0.05,
+alpha = 0.3,
+knot.pos = 0.3
+)
+
+TCM_sankey(...)
+```
+
+参数解析:
+- `data`: A data frame containing at least three columns: herb, molecule, and target.
+- `axis_order`: Character vector specifying the order of axes in the Sankey diagram. Default is c("herb", "molecule", "target").
+- `herb_cols`: Character vector defining the base color palette for the herb layer.
+- `mol_cols`: Character vector defining the base color palette for the molecule.
+- `target_cols`: Character vector defining the base color palette for the target.
+- `plot_font`: Character string specifying the font family used for text. Default is "sans".
+- `font_face`: Character string specifying the font face. Default is "plain".
+- `target_fontface`: Character string specifying the font face for target labels (rightmost axis). Default is "italic".
+- `font_size`: Numeric value controlling the size of node labels. Default is 3.5.
+- `width`: Numeric value controlling the width of both nodes and flows. Default is 0.05.
+- `alpha`: Numeric value controlling the transparency of the flows. Default is 0.3.
+- `knot.pos`: Numeric value (between 0 and 1) determining the curvature position of flow lines. Default is 0.3.
+- `...`: Additional arguments passed to tcm_sankey when using the deprecated alias TCM_sankey.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+tcm_sankey(
+data,
+axis_order = c("herb", "molecule", "target"),
+herb_cols = c("#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b",
+"#e377c2", "#7f7f7f"),
+mol_cols = c("#bcbd22", "#17becf", "#aec7e8", "#ffbb78", "#98df8a", "#ff9896",
+"#c5b0d5", "#E41A1C", "#377EB8"),
+target_cols = c("#c49c94", "#f7b6d2", "#dbdb8d", "#c7e9c0", "#f4cae4", "#e6f598",
+"#ffeda0", "#BB5234", "#BB7813", "#FF6158"),
+plot_font = "sans",
+font_face = "plain",
+target_fontface = "italic",
+font_size = 3.6,
+width = 0.05,
+alpha = 0.3,
+knot.pos = 0.3
+)
+
+TCM_sankey(...)
+```
+
+### `tcm_schema()`
+
+Build a custom output schema for tcm_interpret_schema()
+
+A family of thin wrappers around aisdk::z_object() and the
+associated field constructors. These functions let you define structured
+output contracts without writing aisdk:: anywhere in your code.
+
+Usage:
+```r
+tcm_schema(...)
+
+tcm_field_string(description = "")
+
+tcm_field_number(description = "")
+
+tcm_field_boolean(description = "")
+
+tcm_field_array(description = "")
+
+tcm_field_enum(choices, description = "")
+```
+
+参数解析:
+- `...`: Named field definitions created with tcm_field_*().
+- `description`: Character. Guidance for the model about this field.
+Default "" (no description).
+- `choices`: Character vector of allowed values (for tcm_field_enum
+only).
+
+使用示例:
+```r
+my_schema <- tcm_schema(
+summary     = tcm_field_string("2-3 sentence overview"),
+mechanism   = tcm_field_string("Key molecular mechanism"),
+key_targets = tcm_field_array("Top gene or protein targets"),
+score       = tcm_field_number("Confidence score 0-1"),
+is_tcm      = tcm_field_boolean("Whether TCM herbs are involved"),
+confidence  = tcm_field_enum(c("high", "medium", "low"))
+)
+
+res <- tcm_interpret_schema(enrich_res, schema = my_schema,
+language = "zh")
+res$output$summary
+res$output$key_targets   # character vector
+res$output$confidence    # one of "high" / "medium" / "low"
+```
+
+### `tcm_setup()`
+
+Initialise the AI model from .env or explicit arguments
+
+Loads .env (if present), resolves TCM_* variables, calls
+the matching aisdk::create_*() function, and registers the model via
+aisdk::set_model(). All subsequent AI functions then work without
+further setup.
+
+Usage:
+```r
+tcm_setup(
+provider = NULL,
+api_key = NULL,
+model = NULL,
+base_url = NULL,
+.env = TRUE,
+save = FALSE,
+test = FALSE,
+force_json_schema = TRUE,
+skip_internet_check = TRUE
+)
+```
+
+参数解析:
+- `provider`: Character or NULL. Overrides TCM_PROVIDER.
+- `api_key`: Character or NULL. Overrides TCM_API_KEY.
+- `model`: Character or NULL. Overrides TCM_MODEL.
+- `base_url`: Character or NULL. Overrides TCM_BASE_URL.
+- `.env`: Logical. Load .env before reading env vars (default TRUE).
+- `save`: Logical. If TRUE, also calls tcm_config() to
+persist the resolved credentials to .env. Useful for first-time
+setup when you want a single call to both initialise and save.
+Default FALSE.
+- `test`: Logical. If TRUE, sends a minimal test request after setup to
+verify the API key and endpoint are reachable. Warnings (not errors) are
+issued on failure so the model is still registered. Default FALSE.
+- `force_json_schema`: Logical. Default TRUE. When TRUE,
+every generate_object() call internally re-passes the output schema
+as response_format, which (a) enables native JSON schema output on
+models that support the OpenAI structured-output API and (b) forces
+OpenAI-compatible proxies to preserve the system message that
+contains the schema instruction (some 3rd-party relay APIs silently strip
+the system message when response_format is absent).
+Set FALSE only when targeting a provider whose API rejects an
+unknown response_format field entirely.
+- `skip_internet_check`: Logical. Default TRUE. Sets
+options(aisdk.skip_internet_check = TRUE) before live requests so
+curl::has_internet() false negatives in proxy/VPN environments do
+not block otherwise reachable API endpoints.
+
+使用示例:
+```r
+# Standard two-step workflow
+tcm_config("openai", "sk-xxx", "gpt-4o-mini")
+tcm_setup()
+
+# One-step: configure + initialise in a single call
+tcm_setup("openai", "sk-xxx", "gpt-4o-mini", save = TRUE)
+
+# Verify connectivity after setup
+tcm_setup(test = TRUE)
+
+# Override at runtime without touching .env
+tcm_setup("deepseek", api_key = "sk-xxx", model = "deepseek-chat")
+```
+
+### `tcm_skill_dir()`
+
+Get the active skills directory
+
+Returns the current skills directory path. If a user-local directory has been
+set via tcm_init_skills or tcm_use_skills, that
+path is returned. Otherwise, returns the package default.
+
+Usage:
+```r
+tcm_skill_dir()
+```
+
+参数解析:
+- No user-facing parameters; call exactly as shown in Usage.
+
+使用示例:
+```r
+tcm_skill_dir()
+```
+
+### `tcm_use_skills()`
+
+Set the active skills directory
+
+Points the agent to an existing skills directory. All subsequent calls to
+tcm_agent, tcm_chat, and
+create_tcm_task_agent will use skills from this directory.
+
+Usage:
+```r
+tcm_use_skills(path)
+```
+
+参数解析:
+- `path`: Character. Path to an existing skills directory containing
+skill subdirectories with SKILL.md files.
+
+使用示例:
+```r
+tcm_use_skills("my_project/skills")
+```
+
+## Other utilities
+
+### `draft_result_paragraph()`
+
+Draft a publication-ready result paragraph
+
+Accepts either a tcm_ai_analysis object (from any
+interpret_* function) or a raw analysis object. When a
+raw object is supplied, the context is compressed on the fly.
+
+Usage:
+```r
+draft_result_paragraph(
+x,
+type = c("enrichment", "ppi", "table"),
+language = c("zh", "en"),
+prompt = NULL,
+model = NULL
+)
+```
+
+参数解析:
+- `x`: A tcm_ai_analysis object, or a raw analysis
+object (enrichResult, igraph, data.frame).
+- `type`: Character. Required when x is a raw object.
+One of "enrichment", "ppi", "table".
+- `language`: Character. "zh" or "en".
+Default "zh".
+- `prompt`: Character or NULL. Custom drafting instruction. Replaces the
+default "Draft a result paragraph from this {type} data:"
+opening; the compressed data context is always appended regardless.
+Use this to steer tone, focus, or word count, e.g.
+"Summarise the following enrichment in no more than 3 sentences,
+focusing on immune-related pathways:".
+- `model`: Model identifier or NULL.
+
+使用示例:
+```r
+ai_res <- interpret_enrichment(enrich_res)
+draft  <- draft_result_paragraph(ai_res)
+cat(draft$draft$paragraph)
+
+# Custom instruction
+draft2 <- draft_result_paragraph(ai_res,
+prompt = "用不超过3句话总结，聚焦免疫相关通路，语气适合高水平期刊：")
+```
+
+### `getGores()`
+
+Prepare input data for enrich_circle_plot
+
+Prepare input data for enrich_circle_plot
+
+Usage:
+```r
+getGores(x, up_genes = NULL, down_genes = NULL, top = 10)
+```
+
+参数解析:
+- `x`: enrichResult object or data.frame from clusterProfiler
+with columns: ID, ONTOLOGY, BgRatio, p.adjust, geneID, Count, GeneRatio and RichFactor.
+- `up_genes`: Character vector of up-regulated genes (same ID space as geneID).
+- `down_genes`: Character vector of down-regulated genes (same ID space as geneID).
+- `top`: Numeric. Number of pathways to keep per category (by ascending p.adjust). Default 10.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+getGores(x, up_genes = NULL, down_genes = NULL, top = 10)
+```
+
+### `getMCODE_res()`
+
+Extract MCODE analysis results as a data frame
+
+Extract MCODE analysis results as a data frame
+
+Usage:
+```r
+get_mcode_res(g, only_clusters = FALSE)
+
+getMCODE_res(...)
+```
+
+参数解析:
+- `g`: An igraph object processed by runMCODE.
+- `only_clusters`: Logical. If TRUE, returns only nodes that belong to a cluster. Default FALSE.
+- `...`: Additional arguments passed to get_mcode_res when using the deprecated alias getMCODE_res.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- runMCODE(demo_ppi, max_depth = 100)
+MCODE_res <- get_mcode_res(ppi)
+print(head(MCODE_res))
+```
+
+### `interpret_table()`
+
+Interpret a data.frame (table) with AI
+
+Accepts any data.frame and serialises it row-by-row into a compact
+key=value format before sending to the model.
+
+Usage:
+```r
+interpret_table(
+x,
+top_n = 20,
+audience = "researcher",
+language = c("zh", "en"),
+role = NULL,
+system = NULL,
+prompt = NULL,
+model = NULL
+)
+```
+
+参数解析:
+- `x`: A data.frame.
+- `top_n`: Integer. Number of top rows to include. Default 20.
+- `audience`: Character. Default "researcher".
+Also accepts free-text descriptions.
+- `language`: Character. Default "zh".
+- `role`: Character or NULL. The AI's identity description. Replaces the
+default opening line; other constraints are preserved. Ignored when
+system is provided.
+- `system`: Character or NULL. Full system prompt override.
+- `prompt`: Character or NULL. Custom user prompt instruction.
+- `model`: Model identifier or NULL.
+
+使用示例:
+```r
+interpret_table(my_df)
+interpret_table(my_df, role = "You are a clinical data analyst.")
+```
+
+### `PlotNodeHeatmap()`
+
+Plot PPI nodes metrics Heatmap
+
+Create a Z-score normalized heatmap of PPI node topological metrics using
+ComplexHeatmap.  Provides convenient parameters for the most common
+styling adjustments while still accepting any additional argument via
+....
+
+Usage:
+```r
+plot_node_heatmap(
+data,
+id_col = "name",
+select_cols = NULL,
+colors = c("#2166AC", "white", "#B2182B"),
+cluster_rows = TRUE,
+cluster_cols = FALSE,
+row_fontsize = 12,
+row_fontface = "italic",
+col_fontsize = 10,
+col_fontface = "bold",
+col_rotation = 45,
+show_row_names = TRUE,
+show_column_names = TRUE,
+legend_title = "Z-score",
+border_color = "white",
+border_width = 1,
+...
+)
+
+PlotNodeHeatmap(...)
+```
+
+参数解析:
+- `data`: A data frame containing the node names and metric values.
+- `id_col`: Character. The column name serving as row identifiers.
+Default is "name".
+- `select_cols`: Character vector. Columns to include in the heatmap.
+If NULL (default), all numeric columns except id_col are
+used.
+- `colors`: Character vector of length 3. Colours mapped to Z-score
+values -2, 0, and 2. Default is
+c("#2166AC", "white", "#B2182B").
+- `cluster_rows`: Logical. Perform hierarchical clustering on rows?
+Default TRUE.
+- `cluster_cols`: Logical. Perform hierarchical clustering on columns?
+Default FALSE.
+- `row_fontsize`: Numeric. Font size for row (gene) names.
+Default 12.
+- `row_fontface`: Character. Font face for row names. One of
+"plain", "italic", "bold", or
+"bold.italic". Default "italic".
+- `col_fontsize`: Numeric. Font size for column (metric) names.
+Default 10.
+- `col_fontface`: Character. Font face for column names. Default
+"bold".
+- `col_rotation`: Numeric. Rotation angle (degrees) for column labels.
+Default 45.
+- `show_row_names`: Logical. Show row names? Default TRUE.
+- `show_column_names`: Logical. Show column names? Default TRUE.
+- `legend_title`: Character. Title for the colour legend. Default
+"Z-score".
+- `border_color`: Character. Cell border colour. Default "white".
+Set to NA to remove borders.
+- `border_width`: Numeric. Cell border line width. Default 1.
+- `...`: Additional arguments passed to
+Heatmap.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- compute_nodeinfo(demo_ppi)
+rk_res <- rank_ppi_nodes(ppi)[[2]]
+selected_cols <- colnames(rk_res)[c(2, 3, 4, 6, 9, 12, 14, 15, 16)]
+p1 <- plot_node_heatmap(rk_res, select_cols = selected_cols)
+print(p1)
+```
+
+### `prepare_herb_graph()`
+
+Prepare an igraph object from a Herb–Molecule–Target data frame
+
+Prepare an igraph object from a Herb–Molecule–Target data frame
+
+Usage:
+```r
+prepare_herb_graph(
+df,
+n = NULL,
+herb_col = "herb",
+molecule_col = "molecule",
+target_col = "target",
+compute_metrics = TRUE
+)
+```
+
+参数解析:
+- `df`: A data.frame with three columns representing herb–molecule–target relationships.
+- `n`: Integer. Optional. The number of rows to use from df. Default is 'nrow(df)'
+- `herb_col`: Character. The column name corresponding to herbs. Default is "herb".
+- `molecule_col`: Character. The column name corresponding to molecules/compounds. Default is "molecule".
+- `target_col`: Character. The column name corresponding to targets. Default is "target".
+- `compute_metrics`: Logical. Whether to compute and attach node-level metrics. Default is TRUE.
+
+使用示例:
+```r
+library(igraph)
+library(ggplot2)
+herbs <- c("灵芝")
+lz <- search_herb(herb = herbs, type = "Herb_cn_name")[1:40, ]
+res <- prepare_herb_graph(lz)
+
+# visualization
+p <- ggtangle::ggplot(res, layout = "kk") +
+ggtangle::geom_edge(alpha = 0.4) +
+ggrepel::geom_text_repel(aes(label = name), size = 3.5, max.overlaps = 20) +
+geom_point(aes(color = type, size = centrality)) +
+scale_color_manual(values = c(
+"Herb" = "#E41A1C", "Molecule" = "#377EB8", "Target" = "#4DAF4A")) +
+theme_void()
+print(p)
+```
+
+### `runMCODE()`
+
+Molecular Complex Detection (MCODE) method for identifying PPI clusters.
+
+Molecular Complex Detection (MCODE) method for identifying PPI clusters.
+
+Usage:
+```r
+run_mcode(
+g,
+vwp = 0.2,
+degree_cutoff = 2,
+k_core_threshold = 2,
+haircut = TRUE,
+fluff = FALSE,
+fdt = 0.1,
+loops = FALSE,
+max_depth = 100
+)
+
+runMCODE(...)
+```
+
+参数解析:
+- `g`: An igraph object (PPI network).
+- `vwp`: Numeric. Node Score Cutoff (Vertex Weight Percentage). Default 0.2.
+- `degree_cutoff`: Numeric. Nodes with degree < cutoff will get a score of 0. Default 2.
+- `k_core_threshold`: Numeric. Filters out clusters that do not contain a k-core of at least this level. Default 2.
+- `haircut`: Logical. Whether to prune singly-connected nodes. Default TRUE.
+- `fluff`: Logical. Whether to expand cluster by adding dense neighbors. Default FALSE.
+- `fdt`: Numeric. Fluff Node Density Cutoff. Used if fluff=TRUE. Default 0.1.
+- `loops`: Logical. Whether to include self-loops in scoring. Default FALSE.
+- `max_depth`: Numeric. Maximum recursion depth for cluster finding (to prevent stack overflow on huge networks). Default 100.
+- `...`: Additional arguments passed to run_mcode when using the deprecated alias runMCODE.
+
+使用示例:
+```r
+data(demo_ppi)
+ppi <- run_mcode(demo_ppi, max_depth = 100)
+str(ppi)
+```
+
+### `select_features()`
+
+Re-select top features from a fitted ML model
+After running a model (especially Ridge or XGBoost where all features
+are initially retained), inspect result$importance to decide
+how many to keep, then call this function to trim the selection.
+
+Re-select top features from a fitted ML model
+After running a model (especially Ridge or XGBoost where all features
+are initially retained), inspect result$importance to decide
+how many to keep, then call this function to trim the selection.
+
+Usage:
+```r
+select_features(ml_obj, top_n)
+```
+
+参数解析:
+- `ml_obj`: A tcm_ml object from any ml_* function.
+- `top_n`: Integer; the number of top features to keep (ranked by importance).
+
+使用示例:
+```r
+xgb <- ml_xgboost(ml_data)        # keep all features as default
+head(xgb$importance, 20)           # inspect ranking
+xgb <- select_features(xgb, 15)   # keep top 15
+```
+
+## Machine learning and diagnostic plots
+
+### `get_enet_coefs()`
+
+Extract ranked coefficients from LASSO / Elastic Net / Ridge
+
+Extract ranked coefficients from LASSO / Elastic Net / Ridge
+
+Usage:
+```r
+get_enet_coefs(
+ml_obj,
+top_n = NULL,
+min_coef = 0,
+sort_by = c("abs", "coef"),
+include_zero = FALSE
+)
+```
+
+参数解析:
+- `ml_obj`: A tcm_ml object from ml_lasso(), ml_enet(), or ml_ridge().
+- `top_n`: Return only top-n genes (optional).
+- `min_coef`: Minimum absolute coefficient. Default 0.
+- `sort_by`: "abs" or "coef". Default "abs".
+- `include_zero`: Logical. Whether to include zero-coefficient genes. Default FALSE.
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res <- ml_lasso(ml_data)
+get_enet_coefs(res, top_n = 20)
+```
+
+### `get_gene_auc()`
+
+Compute single-gene AUC for diagnostic evaluation
+
+For each gene the function treats its expression as a univariate predictor,
+computes a ROC curve via pROC, and returns a summary table with AUC,
+95 \% DeLong confidence interval, optimal cutoff (Youden's J), sensitivity,
+specificity and a one-sided test against AUC = 0.5.
+
+Usage:
+```r
+get_gene_auc(
+genes,
+ml_data = NULL,
+expr_mat = NULL,
+group = NULL,
+use = c("auto", "train", "test"),
+ci = TRUE,
+p_adjust_method = "BH"
+)
+```
+
+参数解析:
+- `genes`: Character vector of gene symbols to evaluate.
+- `ml_data`: A tcm_ml_data object from prepare_ml_data
+(preferred input).  When provided, expr_mat / group are
+ignored.
+- `expr_mat`: Numeric matrix (genes \times samples) with
+rownames = gene symbols.  Used only when ml_data is
+NULL.
+- `group`: Factor or character vector of sample labels (length =
+ncol(expr_mat), two levels).
+- `use`: Which data split to evaluate when using ml_data:
+"auto" (default; test set if available, else train),
+"train", or "test".
+- `ci`: Logical; compute 95 \% DeLong confidence interval?
+Default TRUE.
+- `p_adjust_method`: Method for multiple-testing correction passed to
+p.adjust.  Default "BH" (Benjamini--Hochberg
+FDR).  Other common choices: "bonferroni", "holm",
+"none".  When only a single gene is supplied no correction is
+needed and p_adj equals p_value regardless of method.
+
+使用示例:
+```r
+consensus <- get_ml_consensus(ml_list, min_methods = 2)
+auc_tbl <- get_gene_auc(consensus, ml_data = ml_data)
+auc_tbl
+```
+
+### `get_ml_consensus()`
+
+Consensus features across ML methods
+Genes selected by >= min_methods models.
+
+Consensus features across ML methods
+Genes selected by >= min_methods models.
+
+Usage:
+```r
+get_ml_consensus(ml_list, min_methods = 2)
+```
+
+参数解析:
+- `ml_list`: A tcm_ml_list or plain list of tcm_ml objects.
+- `min_methods`: Minimum agreement count. Default 2.
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res_list <- run_ml_screening(ml_data)
+get_ml_consensus(res_list, min_methods = 2)
+```
+
+### `get_ml_gene_sets()`
+
+Extract gene sets from ML results
+
+Flexibly accepts the output of run_ml_screening(), individually fitted
+tcm_ml objects, or plain character vectors, and returns a named list
+of character vectors ready for downstream plotting.
+
+Usage:
+```r
+get_ml_gene_sets(..., set_names = NULL)
+```
+
+参数解析:
+- `...`: One of the following:
+
+A single tcm_ml_listfrom run_ml_screening().
+Multiple tcm_ml objectse.g.
+get_ml_gene_sets(res_lasso, res_rf, res_xgb).
+A single named listof character vectors or tcm_ml objects.
+Multiple character vectorsgene sets directly.
+- `set_names`: Optional character vector of names for the sets.
+Ignored when names can be inferred from the input.
+
+使用示例:
+```r
+## From run_ml_screening()
+gene_sets <- get_ml_gene_sets(ml_list)
+
+## From individual models
+gene_sets <- get_ml_gene_sets(res_lasso, res_rf, res_xgb)
+
+## Venn diagram (2-4 sets)
+venn_df <- do.call(getvenndata,
+c(gene_sets, list(set_names = names(gene_sets))))
+ggvenn_plot(venn_df)
+
+## UpSet plot (usually more than 4 sets)
+upsetplot(gene_sets)
+```
+
+### `ml_enet()`
+
+Elastic Net feature selection via cv.glmnet
+Penalised logistic regression with configurable alpha.
+
+alpha = 1 : LASSO
+alpha = 0 : Ridge
+0 < alpha < 1 : Elastic Net
+
+Caution: For Ridge (alpha = 0), all coefficients are non-zero.
+When top_n = NULL (default), all features are retained so that
+users can inspect $importance first, then call
+select_features() to trim to the desired number.
+
+Elastic Net feature selection via cv.glmnet
+Penalised logistic regression with configurable alpha.
+
+alpha = 1 : LASSO
+alpha = 0 : Ridge
+0 < alpha < 1 : Elastic Net
+
+Caution: For Ridge (alpha = 0), all coefficients are non-zero.
+When top_n = NULL (default), all features are retained so that
+users can inspect $importance first, then call
+select_features() to trim to the desired number.
+
+Usage:
+```r
+ml_enet(
+ml_data,
+alpha = 0.5,
+lambda_rule = c("1se", "min"),
+top_n = NULL,
+type_measure = "auc",
+cv_folds = 10,
+seed = 2025,
+...
+)
+```
+
+参数解析:
+- `ml_data`: A tcm_ml_data object from prepare_ml_data().
+- `alpha`: Mixing parameter, 0 to 1. Default 0.5.
+- `lambda_rule`: "1se" (parsimonious) or "min" (best AUC).
+- `top_n`: For Ridge: max number of top genes to keep (by
+abs(coefficient)). Default NULL (keep all).
+Ignored for LASSO / Elastic Net.
+- `type_measure`: Loss function for CV in glmnet::cv.glmnet().
+Default "auc". Other options: "deviance",
+"class", "mse", "mae".
+- `cv_folds`: Number of CV folds. Default 10.
+- `seed`: Random seed. Default 2025.
+- `...`: Passed to glmnet::cv.glmnet().
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res <- ml_enet(ml_data)
+```
+
+### `ml_lasso()`
+
+LASSO feature selection (a wrapper function from ml_enet())
+Calls ml_enet() with alpha = 1.
+
+LASSO feature selection (a wrapper function from ml_enet())
+Calls ml_enet() with alpha = 1.
+
+Usage:
+```r
+ml_lasso(
+ml_data,
+lambda_rule = c("1se", "min"),
+cv_folds = 10,
+seed = 2025,
+...
+)
+```
+
+参数解析:
+- `ml_data`: A tcm_ml_data object from prepare_ml_data().
+- `lambda_rule`: "1se" (parsimonious) or "min" (best AUC).
+- `cv_folds`: Number of CV folds. Default 10.
+- `seed`: Random seed. Default 2025.
+- `...`: Passed to glmnet::cv.glmnet().
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res <- ml_lasso(ml_data)
+```
+
+### `ml_rf()`
+
+Random Forest + Boruta feature selection for key-gene screening
+
+Supervised feature-selection pipeline designed for network-pharmacology
+workflows: starting from PPI-derived candidate genes and RNA-seq expression
+profiles, this function identifies a stable, interpretable set of key genes
+rather than optimising prediction accuracy.
+
+Pipeline overview
+
+Train a Random Forest on all candidate genes to obtain
+importance scores (MeanDecreaseGini / MeanDecreaseAccuracy).
+Run Boruta all-relevant feature selection; tentative features are
+resolved via TentativeRoughFix.
+(Optional, default) Re-fit a Random Forest on the selected
+genes only so that OOB and test-set metrics honestly reflect the
+chosen subset (refit_on_selected = TRUE).
+
+Usage:
+```r
+ml_rf(
+ml_data,
+n_trees = 500,
+top_n = NULL,
+boruta_fallback_n = 20,
+max_runs = 100,
+refit_on_selected = TRUE,
+seed = 2025,
+...
+)
+```
+
+参数解析:
+- `ml_data`: A tcm_ml_data object produced by prepare_ml_data. Must contain exactly two classes.
+- `n_trees`: Number of trees for both the initial RF and the refit RF. Default 500.
+- `top_n`: Hard cap: keep at most top_n Boruta-confirmed genes (ranked by MeanDecreaseGini). NULL = no cap (default).
+- `boruta_fallback_n`: When Boruta confirms zero features, fall back to the top-boruta_fallback_n genes ranked by MeanDecreaseGini.
+Default 20.
+- `max_runs`: Maximum Boruta iterations passed to Boruta. Default 100.
+- `refit_on_selected`: Logical. Re-fit a RF on selected genes only so that OOB / test metrics reflect the actual feature subset. Default TRUE (recommended).
+- `seed`: Random seed. Default 2025.
+- `...`: Additional arguments forwarded to randomForest.
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res <- ml_rf(ml_data)
+```
+
+### `ml_ridge()`
+
+Ridge regression feature selection (a wrapper function from ml_enet())
+Calls ml_enet() with alpha = 0.
+Caution: Ridge does not shrink coefficients to zero; when top_n = NULL
+(default), all features are kept. Use select_features() after inspecting importance to trim.
+
+Ridge regression feature selection (a wrapper function from ml_enet())
+Calls ml_enet() with alpha = 0.
+Caution: Ridge does not shrink coefficients to zero; when top_n = NULL
+(default), all features are kept. Use select_features() after inspecting importance to trim.
+
+Usage:
+```r
+ml_ridge(
+ml_data,
+lambda_rule = c("1se", "min"),
+top_n = NULL,
+cv_folds = 10,
+seed = 2025,
+...
+)
+```
+
+参数解析:
+- `ml_data`: A tcm_ml_data object from prepare_ml_data().
+- `lambda_rule`: "1se" (parsimonious) or "min" (best AUC).
+- `top_n`: For Ridge: max number of top genes to keep (by
+abs(coefficient)). Default NULL (keep all).
+Ignored for LASSO / Elastic Net.
+- `cv_folds`: Number of CV folds. Default 10.
+- `seed`: Random seed. Default 2025.
+- `...`: Passed to glmnet::cv.glmnet().
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res <- ml_ridge(ml_data)
+```
+
+### `ml_svm_rfe()`
+
+SVM-RFE feature selection
+Recursive Feature Elimination with SVM via caret::rfe().
+Designed for binary classification of gene expression data (e.g. RNA-seq
+profiles of PPI candidate genes vs. disease/control labels).
+
+SVM-RFE feature selection
+Recursive Feature Elimination with SVM via caret::rfe().
+Designed for binary classification of gene expression data (e.g. RNA-seq
+profiles of PPI candidate genes vs. disease/control labels).
+
+Usage:
+```r
+ml_svm_rfe(
+ml_data,
+sizes = NULL,
+top_n = NULL,
+min_size = 5,
+kernel = c("svmLinear", "svmRadial"),
+metric = "ROC",
+cv_folds = 5,
+cv_repeats = 5,
+seed = 2025,
+...
+)
+```
+
+参数解析:
+- `ml_data`: A tcm_ml_data object. Must contain exactly two classes.
+- `sizes`: Integer vector of feature-subset sizes to evaluate in RFE.
+Default NULL: sizes are derived automatically from the data by
+log-spacing 10 values from 2 to min(p - 1, max(p %/% 2, 50)),
+where p is the number of input features. When provided manually,
+values outside [2, p] are silently dropped.
+- `top_n`: Override the auto-selected optimal size: keep the top
+top_n genes by aggregated importance. Default NULL
+(use the size that maximises metric in the RFE profile).
+- `min_size`: Minimum number of features to retain. The profile search
+is restricted to Variables >= min_size. Default 5.
+Useful to avoid biologically trivial 2-3 gene subsets.
+- `kernel`: SVM kernel to use. "svmLinear" (default, recommended
+for gene expression data — weights |w_j|^2 are directly used for
+recursive elimination per Guyon 2002) or "svmRadial".
+- `metric`: Optimization metric for RFE. Default "ROC".
+Other options include "Accuracy", "Kappa".
+When "ROC" / "Sens" / "Spec" is used,
+twoClassSummary is applied automatically; otherwise
+defaultSummary is used.
+- `cv_folds`: Outer CV folds. Default 5.
+- `cv_repeats`: Outer CV repeats. Default 5.
+- `seed`: Random seed. Default 2025.
+- `...`: Passed to caret::rfe().
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res <- ml_svm_rfe(ml_data)
+```
+
+### `ml_xgboost()`
+
+XGBoost feature selection
+Trains an XGBoost classifier with nrounds-round CV, then ranks features by information gain.
+Since XGBoost does not inherently perform variable selection, top_n controls how many top features to keep.
+When top_n = NULL (default), all features with Gain > 0 are retained; use select_features() afterwards to trim.
+
+XGBoost feature selection
+Trains an XGBoost classifier with nrounds-round CV, then ranks features by information gain.
+Since XGBoost does not inherently perform variable selection, top_n controls how many top features to keep.
+When top_n = NULL (default), all features with Gain > 0 are retained; use select_features() afterwards to trim.
+
+Usage:
+```r
+ml_xgboost(
+ml_data,
+top_n = NULL,
+eval_metric = "auc",
+nrounds = 200,
+max_depth = 6,
+eta = 0.1,
+cv_folds = 5,
+early_stopping_rounds = 20,
+seed = 2025,
+...
+)
+```
+
+参数解析:
+- `ml_data`: A tcm_ml_data object.
+- `top_n`: Number of top features to select by Gain. Default NULL (keep all).
+- `eval_metric`: Evaluation metric for XGBoost CV. Default "auc".
+Other options include "error", "logloss", "aucpr".
+See xgboost documentation for full list.
+- `nrounds`: Maximum boosting rounds. Default 200.
+- `max_depth`: Maximum tree depth. Default 6.
+- `eta`: Learning rate. Default 0.1.
+- `cv_folds`: CV folds for early stopping. Default 5.
+- `early_stopping_rounds`: Stop if no improvement for this many rounds. Default 20.
+- `seed`: Random seed. Default 2025.
+- `...`: Passed to xgboost::xgb.cv() and xgboost::xgb.train().
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res <- ml_xgboost(ml_data)
+```
+
+### `plot_enet_coefs()`
+
+Bar chart of LASSO / Elastic Net / Ridge coefficients
+
+Horizontal bar chart coloured by sign (positive / negative).
+
+Usage:
+```r
+plot_enet_coefs(result, top_n = 20)
+```
+
+参数解析:
+- `result`: A tcm_ml object from ml_enet(), ml_lasso() or
+ml_ridge().
+- `top_n`: Number of top features to show. Default 20.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_enet_coefs(result, top_n = 20)
+```
+
+### `plot_enet_cv()`
+
+Plot Elastic Net / LASSO / Ridge CV curve
+
+Wrapper around the default plot.cv.glmnet() method from the
+glmnet package. Displays the CV metric (AUC / deviance) as a
+function of \log(\lambda), with ± 1 SE error bars and vertical
+dashed lines at lambda.min and lambda.1se.
+
+Usage:
+```r
+plot_enet_cv(result, ...)
+```
+
+参数解析:
+- `result`: A tcm_ml object from ml_enet(), ml_lasso() or ml_ridge().
+- `...`: Additional arguments passed to plot.cv.glmnet().
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_enet_cv(result, ...)
+```
+
+### `plot_enet_path()`
+
+Plot Elastic Net / LASSO / Ridge coefficient path
+
+Wrapper around the default plot.glmnet() method.
+Each curve traces one feature's coefficient across the \lambda grid.
+When top_n is set, only the features with the largest absolute
+coefficients at the selected \lambda are shown.
+
+Usage:
+```r
+plot_enet_path(result, top_n = 20, xvar = "lambda", ...)
+```
+
+参数解析:
+- `result`: A tcm_ml object from ml_enet(), ml_lasso() or ml_ridge().
+- `top_n`: Integer or NULL. If non-NULL and fewer features
+than the total, only the top_n features with largest absolute
+coefficient at the selected \lambda are drawn. Default 20.
+- `xvar`: Variable on x-axis: "lambda" (default), "norm", or "dev".
+- `...`: Additional arguments passed to plot.glmnet().
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_enet_path(result, top_n = 20, xvar = "lambda", ...)
+```
+
+### `plot_gene_boxplot()`
+
+Two-group expression boxplots for diagnostic genes
+
+Draws a faceted boxplot comparing expression levels between two groups for
+each gene, with optional jittered points, violin overlay and statistical
+test annotation.  Designed for publication-quality figures with zero extra
+dependencies beyond ggplot2 and base R stats.
+
+Usage:
+```r
+plot_gene_boxplot(
+genes,
+ml_data = NULL,
+expr_mat = NULL,
+group = NULL,
+use = c("auto", "train", "test"),
+test_method = c("wilcox", "t.test"),
+palette = c("#E74C3C", "#3498DB"),
+show_points = TRUE,
+point_alpha = 0.35,
+violin = FALSE,
+ncol = NULL,
+scales = "free_y",
+p_label = c("p.format", "p.signif", "p.adj"),
+p_adjust_method = "BH",
+base_size = 12
+)
+```
+
+参数解析:
+- `genes`: Character vector of gene symbols to evaluate.
+- `ml_data`: A tcm_ml_data object from prepare_ml_data
+(preferred input).  When provided, expr_mat / group are
+ignored.
+- `expr_mat`: Numeric matrix (genes \times samples) with
+rownames = gene symbols.  Used only when ml_data is
+NULL.
+- `group`: Factor or character vector of sample labels (length =
+ncol(expr_mat), two levels).
+- `use`: Which data split to evaluate when using ml_data:
+"auto" (default; test set if available, else train),
+"train", or "test".
+- `test_method`: Statistical test: "wilcox" (Wilcoxon rank-sum,
+default) or "t.test".
+- `palette`: Character(2); fill colours for the two groups.
+Default c("#E74C3C", "#3498DB") (red / blue).
+- `show_points`: Logical; overlay jittered data points? Default TRUE.
+- `point_alpha`: Alpha transparency for jittered points. Default 0.35.
+- `violin`: Logical; add a violin layer behind the boxes?
+Default FALSE.
+- `ncol`: Integer; number of columns in facet_wrap.
+Default NULL (auto-computed).
+- `scales`: Passed to facet_wrap.
+Default "free_y".
+- `p_label`: How to annotate p-values: "p.format" (numeric,
+default), "p.signif" (stars: ns / * / ** / *** / ****), or
+"p.adj" (adjusted, numeric).
+- `p_adjust_method`: Method for multiple-testing correction passed to
+p.adjust.  Default "BH".  Applies both to the
+p_adj column in attr(, "test_table") and to the annotation
+when p_label = "p.adj".  When only a single gene is tested,
+p_adj equals p_value regardless of method.
+- `base_size`: Base font size for theme_bw.
+Default 12.
+
+使用示例:
+```r
+consensus <- get_ml_consensus(ml_list, min_methods = 2)
+plot_gene_boxplot(consensus, ml_data = ml_data)
+plot_gene_boxplot(consensus, expr_mat = expr_mat, group = group,
+violin = TRUE, p_label = "p.signif")
+```
+
+### `plot_gene_roc()`
+
+ROC curves for individual diagnostic genes
+
+Overlays one ROC curve per gene on a single panel (combine = TRUE,
+default), or draws one ROC per facet (combine = FALSE).
+This is the natural follow-up after get_ml_consensus: the
+consensus genes are fed back to evaluate their individual diagnostic power.
+
+Usage:
+```r
+plot_gene_roc(
+genes,
+ml_data = NULL,
+expr_mat = NULL,
+group = NULL,
+use = c("auto", "train", "test"),
+combine = TRUE,
+palette = NULL,
+show_ci = FALSE,
+ncol = NULL,
+label_size = 9,
+p_adjust_method = "BH"
+)
+```
+
+参数解析:
+- `genes`: Character vector of gene symbols to evaluate.
+- `ml_data`: A tcm_ml_data object from prepare_ml_data
+(preferred input).  When provided, expr_mat / group are
+ignored.
+- `expr_mat`: Numeric matrix (genes \times samples) with
+rownames = gene symbols.  Used only when ml_data is
+NULL.
+- `group`: Factor or character vector of sample labels (length =
+ncol(expr_mat), two levels).
+- `use`: Which data split to evaluate when using ml_data:
+"auto" (default; test set if available, else train),
+"train", or "test".
+- `combine`: Logical; if TRUE (default) all curves are overlaid on one panel.  If FALSE each gene gets its own facet.
+- `palette`: Character vector of colours (one per gene), or NULL for the built-in 12-colour publication palette.
+- `show_ci`: Logical; Whether to add a translucent 95 percent CI band around each curve. Default FALSE.  Requires pROC::ci.se().
+- `ncol`: Integer; number of columns when combine = FALSE. Default NULL (auto).
+- `label_size`: Legend text size. Default 9.
+- `p_adjust_method`: Method for multiple-testing correction passed to
+p.adjust.  Default "BH" (Benjamini--Hochberg
+FDR).  Other common choices: "bonferroni", "holm",
+"none".  When only a single gene is supplied no correction is
+needed and p_adj equals p_value regardless of method.
+
+使用示例:
+```r
+consensus <- get_ml_consensus(ml_list, min_methods = 2)
+plot_gene_roc(consensus, ml_data = ml_data)
+plot_gene_roc(consensus, ml_data = ml_data, combine = FALSE)
+```
+
+### `plot_ml_roc()`
+
+ROC curves for ML methods
+
+Supports all modes.
+
+Mode B / C: ROC is computed on the held-out test set.
+Mode A: uses out-of-fold (LASSO / Enet / XGBoost / SVM-RFE) or OOB (RF)
+predictions.
+SVM-RFE falls back to resubstitution when OOF is unavailable.
+
+Usage:
+```r
+plot_ml_roc(ml_list)
+```
+
+参数解析:
+- `ml_list`: A tcm_ml_list from run_ml_screening().
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_ml_roc(ml_list)
+```
+
+### `plot_ml_venn()`
+
+Venn diagram of selected genes
+
+Convenience wrapper: calls get_ml_gene_sets() to extract gene sets,
+then draws a Venn diagram via getvenndata() + ggvenn_plot().
+Accepts the same flexible inputs as get_ml_gene_sets().
+For > 4 sets consider using upsetplot(get_ml_gene_sets(...)).
+
+Usage:
+```r
+plot_ml_venn(..., set_names = NULL)
+```
+
+参数解析:
+- `...`: One of the following:
+
+A single tcm_ml_listfrom run_ml_screening().
+Multiple tcm_ml objectse.g.
+get_ml_gene_sets(res_lasso, res_rf, res_xgb).
+A single named listof character vectors or tcm_ml objects.
+Multiple character vectorsgene sets directly.
+- `set_names`: Optional character vector of names for the sets.
+Ignored when names can be inferred from the input.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_ml_venn(..., set_names = NULL)
+```
+
+### `plot_rf_boruta()`
+
+Plot Boruta feature selection result
+
+Plot Boruta feature selection result
+
+Usage:
+```r
+plot_rf_boruta(result, top_n = 20)
+```
+
+参数解析:
+- `result`: A tcm_ml object from ml_rf().
+- `top_n`: Integer; show at most this many features.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_rf_boruta(result, top_n = 20)
+```
+
+### `plot_rf_importance()`
+
+Plot RF variable importance
+
+Plot RF variable importance
+
+Usage:
+```r
+plot_rf_importance(result, top_n = 20)
+```
+
+参数解析:
+- `result`: A tcm_ml object from ml_rf().
+- `top_n`: Integer; number of top features to show.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_rf_importance(result, top_n = 20)
+```
+
+### `plot_svm_rfe_curve()`
+
+Plot SVM-RFE accuracy profile
+
+Plot SVM-RFE accuracy profile
+
+Usage:
+```r
+plot_svm_rfe_curve(result)
+```
+
+参数解析:
+- `result`: A tcm_ml object from ml_svm_rfe().
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_svm_rfe_curve(result)
+```
+
+### `plot_xgb_importance()`
+
+Plot XGBoost feature importance (Gain)
+
+Plot XGBoost feature importance (Gain)
+
+Usage:
+```r
+plot_xgb_importance(result, top_n = 20)
+```
+
+参数解析:
+- `result`: A tcm_ml object from ml_xgboost().
+- `top_n`: Integer; number of top features to show.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+plot_xgb_importance(result, top_n = 20)
+```
+
+### `prepare_ml_data()`
+
+Prepare expression data for ML feature selection
+
+Supports three modes:
+
+Mode A (default): full-data CV, no hold-out (split = FALSE).
+Mode B: internal train/test split (split = TRUE).
+Mode C: external validation (test_expr + test_group).
+
+Usage:
+```r
+prepare_ml_data(
+expr_mat,
+group,
+positive_class = NULL,
+genes = NULL,
+split = FALSE,
+train_ratio = 0.7,
+train_idx = NULL,
+test_expr = NULL,
+test_group = NULL,
+seed = 2025
+)
+```
+
+参数解析:
+- `expr_mat`: Numeric matrix (genes x samples). Row names = gene symbols.
+- `group`: Factor/character of length ncol(expr_mat), two levels.
+- `positive_class`: Which level to treat as the positive class (levels[[1]]).
+Default NULL: if group is already an ordered factor, its level order is
+preserved; otherwise levels are sorted alphabetically.
+- `genes`: Optional character vector of candidate genes to keep. Default is NULL.
+- `split`: Logical. TRUE = Mode B. Default is FALSE.
+- `train_ratio`: Fraction for training when split = TRUE. Default is 0.7.
+- `train_idx`: Optional integer indices overriding train_ratio.
+- `test_expr`: External validation matrix (genes x samples) for Mode C.
+- `test_group`: Labels for test_expr (required if test_expr given).
+- `seed`: Random seed. Default is 2025.
+
+使用示例:
+```r
+## Mode A: full CV
+ml_data <- prepare_ml_data(expr_mat, group, positive_class = "Disease")
+## Mode B: internal split
+ml_data <- prepare_ml_data(expr_mat, group, split = TRUE, train_ratio = 0.7)
+```
+
+### `run_ml_screening()`
+
+Run multiple ML methods for feature selection
+Convenience wrapper that runs LASSO / Elastic Net / Ridge / RF / SVM-RFE / XGBoost.
+By default top_n = NULL: Ridge and XGBoost retain all features, SVM-RFE auto-selects the optimal size.
+After inspecting results, call select_features() on individual models to trim to the desired count.
+
+Run multiple ML methods for feature selection
+Convenience wrapper that runs LASSO / Elastic Net / Ridge / RF / SVM-RFE / XGBoost.
+By default top_n = NULL: Ridge and XGBoost retain all features, SVM-RFE auto-selects the optimal size.
+After inspecting results, call select_features() on individual models to trim to the desired count.
+
+Usage:
+```r
+run_ml_screening(
+ml_data,
+methods = c("lasso", "rf", "svm_rfe", "xgboost"),
+seed = 2025,
+cv_folds = 5,
+cv_repeats = 5,
+alpha = 0.5,
+top_n = NULL,
+...
+)
+```
+
+参数解析:
+- `ml_data`: A tcm_ml_data object.
+- `methods`: Subset of c("lasso", "enet", "ridge", "rf", "svm_rfe", "xgboost").
+- `seed`: Random seed. Default 2025.
+- `cv_folds`: CV folds. Default 5.
+- `cv_repeats`: SVM-RFE outer CV repeats. Default 5.
+- `alpha`: Elastic Net alpha. Default 0.5 (ignored for lasso/ridge).
+- `top_n`: Top-n features for Ridge / XGBoost / SVM-RFE. Default NULL (keep all or auto-select).
+- `...`: Forwarded to individual model functions.
+
+使用示例:
+```r
+ml_data <- prepare_ml_data(expr_mat, group)
+res_list <- run_ml_screening(ml_data, methods = c("lasso", "rf"))
+summary(res_list)
+```
+
+## Search and evidence retrieval
+
+### `get_pubmed_data()`
+
+PubMed Literature Scraper for TCMDATA
+
+Fetches and summarizes PubMed literature based on specific Traditional Chinese Medicine (TCM)
+and disease keywords within a defined time frame.
+
+Usage:
+```r
+get_pubmed_data(
+tcm_name,
+disease_name,
+year_range = NULL,
+email = NULL,
+retmax = 1000,
+...
+)
+```
+
+参数解析:
+- `tcm_name`: Character. Keywords for the TCM (e.g., "Ginseng").
+- `disease_name`: Character. Keywords for the disease (e.g., "Fatigue").
+- `year_range`: Integer vector of length 2. The publication year range (e.g., c(2015, 2026)).
+- `email`: Character. User email address required by NCBI E-utils.
+- `retmax`: Integer. Maximum number of PMIDs to retrieve. Default is 1000.
+- `...`: Additional arguments passed to other methods.
+
+使用示例:
+```r
+result <- get_pubmed_data(tcm_name = "Artemisinin", 
+disease_name = "Malaria", 
+year_range = c(2020, 2025),
+retmax = 100,
+email = "your email")
+
+print(str(result))
+```
+
+### `get_pubmed_table()`
+
+Extract and Sort PubMed Literature Table
+
+Accesses the literature data within a 'tcm_pubmed' object and returns it as
+a data frame sorted by publication year in descending order.
+
+Usage:
+```r
+get_pubmed_table(x, n = NULL, file = NULL)
+```
+
+参数解析:
+- `x`: An object of class 'tcm_pubmed' generated by get_pubmed_data.
+- `n`: Integer. Number of top records to return. If NULL (default), returns all records.
+- `file`: Character. Optional file path (e.g., "results.csv"). If provided, the table will be saved to this location.
+
+使用示例:
+```r
+## get result from pubmed
+result <- get_pubmed_data(tcm_name = "Artemisinin", 
+disease_name = "Malaria", 
+year_range = c(2020, 2025),
+retmax = 100,
+email = "your email")
+
+# Get the sorted table
+lit_table <- get_pubmed_table(result)
+
+# Get top 10 records and save to CSV
+lit_table <- get_pubmed_table(result, n = 10, file = "top10_lit.csv")
+```
+
+### `search_disease()`
+
+Search disease targets (disease -> genes)
+
+Query DisGeNET (via DOSE) to find genes associated with a disease.
+Supports UMLS CUI IDs, exact name match, or fuzzy name search.
+
+Usage:
+```r
+search_disease(disease, readable = TRUE)
+```
+
+参数解析:
+- `disease`: Character. Disease name or UMLS CUI (e.g. "sepsis" or
+"C0243026"). Supports a vector for multiple diseases.
+- `readable`: Logical. Convert Entrez IDs to gene symbols (default TRUE).
+
+使用示例:
+```r
+search_disease("sepsis")
+search_disease(c("sepsis", "asthma"))
+search_disease("C0243026")
+```
+
+### `search_gene_disease()`
+
+Search gene-associated diseases (gene -> diseases)
+
+Reverse lookup: given gene symbols or Entrez IDs, find associated diseases
+from DisGeNET (via DOSE).
+
+Usage:
+```r
+search_gene_disease(gene, readable = TRUE)
+```
+
+参数解析:
+- `gene`: Character. Gene symbols (e.g. "TNF") or Entrez IDs.
+Supports a vector for multiple genes.
+- `readable`: Logical. Attach gene symbol column (default TRUE).
+
+使用示例:
+```r
+search_gene_disease("TNF")
+search_gene_disease(c("IL6", "TNF", "PPARG"))
+search_gene_disease("7124")
+```
+
+### `search_geo_datasets()`
+
+Search GEO for datasets related to a disease or keyword
+
+Queries the NCBI GEO database (via E-utilities) to find relevant
+expression datasets (GDS/GSE) for a given search term. Useful for
+discovering RNA-seq, microarray, or single-cell datasets before analysis.
+
+Usage:
+```r
+search_geo_datasets(
+query,
+organism = "Homo sapiens",
+dataset_type = NULL,
+email = NULL,
+retmax = 20L
+)
+```
+
+参数解析:
+- `query`: Character. Search query (e.g. disease name, tissue + disease).
+- `organism`: Character. Organism filter. Default "Homo sapiens".
+- `dataset_type`: Character. Optional type filter: "expression profiling by array",
+"expression profiling by high throughput sequencing", or "single-cell".
+Pass NULL to search all types.
+- `email`: Character. Email address required by NCBI E-utilities.
+- `retmax`: Integer. Maximum number of results. Default 20.
+
+使用示例:
+```r
+res <- search_geo_datasets("sepsis", email = "user@example.com")
+head(res)
+```
+
+### `search_herb()`
+
+Retrieve Herbs and Retrieve Associated Molecules and Targets
+
+This function retrieves herb, molecule, and target information from the internal dataset, tcm_data,
+based on specified herb names and their corresponding name types (Chinese, Pinyin, or English).
+
+Usage:
+```r
+search_herb(herb, type)
+```
+
+参数解析:
+- `herb`: A character vector containing the names of herbs to be queried.
+- `type`: A string indicating the type of herb names provided. Must be one of "Herb_cn_name",
+"Herb_pinyin_name", or "Herb_en_name".
+
+使用示例:
+```r
+# Example usage with Chinese herb names
+herbs <- c("灵芝")
+lz <- search_herb(herb = herbs, type = "Herb_cn_name")
+print(lz)
+
+# Example usage with pinyin herb names
+herbs <- c("Ginseng", "Licorice")
+comp <- search_herb(herb = herbs, type = "Herb_pinyin_name")
+print(comp)
+```
+
+### `search_target()`
+
+Retrieve Herbs, Molecules, and Targets Based on Gene List
+
+This function retrieves herb, molecule, and target information from the internal dataset, tcm_data,
+based on a provided list of target genes.
+
+Usage:
+```r
+search_target(gene_list)
+```
+
+参数解析:
+- `gene_list`: A character vector containing gene symbols which can be determined freely by users.
+
+使用示例:
+```r
+# Example usage with a list of gene symbols
+genes <- c("TP53", "EGFR", "BRCA1")
+herbs_targets <- search_target(genes)
+print(herbs_targets)
+```
+
+## General visualization
+
+### `getvenndata()`
+
+Construct a Logical Matrix for Venn Diagram Visualization
+
+This function takes 2 to 4 named character vectors as input, removes duplicates,
+and returns a data frame in logical format that is compatible with ggvenn for Venn diagram plotting.
+
+Usage:
+```r
+getvenndata(..., set_names = NULL)
+```
+
+参数解析:
+- `...`: 2 to 4 character vectors representing different gene sets or element sets.
+- `set_names`: Optional character vector to assign custom names to the sets.
+If not provided, names will be automatically assigned as "Set1", "Set2", etc.
+
+使用示例:
+```r
+# Usage with 3 sets
+targets_db1 <- c("TP53", "EGFR", "KRAS", "MYC", "AKT1")
+targets_db2 <- c("TP53", "KRAS", "PTEN", "BRCA1")
+targets_db3 <- c("EGFR", "MYC", "BRAF", "PTEN", "TP53")
+
+df_venn3 <- getvenndata(targets_db1, targets_db2, targets_db3,
+set_names = c("Database_1", "Database_2", "Database_3"))
+
+head(df_venn3)
+```
+
+### `getvennresult()`
+
+Get all Venn set intersections from getvenndata-style logical matrix
+
+Get all Venn set intersections from getvenndata-style logical matrix
+
+Usage:
+```r
+getvennresult(venn_df, col_names = NULL, drop_empty = TRUE)
+```
+
+参数解析:
+- `venn_df`: A data.frame from getvenndata(), with logical columns
+- `col_names`: Character vector of columns to use (default: all except 1st)
+- `drop_empty`: Logical; whether to drop combinations with 0 genes
+
+使用示例:
+```r
+# Usage with 3 sets
+targets_db1 <- c("TP53", "EGFR", "KRAS", "MYC", "AKT1")
+targets_db2 <- c("TP53", "KRAS", "PTEN", "BRCA1")
+targets_db3 <- c("EGFR", "MYC", "BRAF", "PTEN", "TP53")
+
+df_venn3 <- getvenndata(targets_db1, targets_db2, targets_db3,
+set_names = c("Database_1", "Database_2", "Database_3"))
+
+venn_res <- getvennresult(df_venn3)
+print(venn_res)
+```
+
+### `ggvenn_plot()`
+
+Plot a Venn Diagram for 2–4 Sets Using ggvenn
+
+This is a wrapper around ggvenn() to draw customizable Venn diagrams
+for 2–4 sets with automatic color matching and error handling.
+
+Usage:
+```r
+ggvenn_plot(
+venn_df,
+col_names = NULL,
+set.color = c("#E41A1C", "#1E90FF", "#FF8C00", "#4DAF4A", "#75cbdc"),
+set.name.color = "black",
+use.color.as.text = TRUE,
+name.size = 5,
+text.size = 4,
+stroke.color = "black",
+stroke.size = 0.6,
+show.percentage = FALSE,
+show.elements = FALSE,
+digits = 1,
+expand_ratio = 0.2
+)
+```
+
+参数解析:
+- `venn_df`: A data.frame where the first column is element ID and the remaining 2–4 columns are logical (TRUE/FALSE) indicators for set membership.
+- `col_names`: Character vector of column names to be used as sets. If NULL, all columns except the first are used.
+- `set.color`: Fill colors for Venn sets.
+- `set.name.color`: Color for set name labels (ignored if use.color.as.text = TRUE).
+- `use.color.as.text`: Logical; if TRUE, use fill color as set name text color.
+- `name.size`: Font size for set names.
+- `text.size`: Font size for intersection counts.
+- `stroke.color`: Circle border color. Default is 'black'.
+- `stroke.size`: Circle border thickness. Default is 0.6.
+- `show.percentage`: Logical; whether to show percentages instead of raw counts.
+- `show.elements`: Logical; whether to display individual elements in each region.
+- `digits`: Number of decimal places for percentage display.
+- `expand_ratio`: Plot margin expansion ratio for aesthetics.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+ggvenn_plot(
+venn_df,
+col_names = NULL,
+set.color = c("#E41A1C", "#1E90FF", "#FF8C00", "#4DAF4A", "#75cbdc"),
+set.name.color = "black",
+use.color.as.text = TRUE,
+name.size = 5,
+text.size = 4,
+stroke.color = "black",
+stroke.size = 0.6,
+show.percentage = FALSE,
+show.elements = FALSE,
+digits = 1,
+expand_ratio = 0.2
+)
+```
+
+### `TCM_sankey()`
+
+TCM Sankey Plot for herb-molecule-target
+
+TCM Sankey Plot for herb-molecule-target
+
+Usage:
+```r
+tcm_sankey(
+data,
+axis_order = c("herb", "molecule", "target"),
+herb_cols = c("#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b",
+"#e377c2", "#7f7f7f"),
+mol_cols = c("#bcbd22", "#17becf", "#aec7e8", "#ffbb78", "#98df8a", "#ff9896",
+"#c5b0d5", "#E41A1C", "#377EB8"),
+target_cols = c("#c49c94", "#f7b6d2", "#dbdb8d", "#c7e9c0", "#f4cae4", "#e6f598",
+"#ffeda0", "#BB5234", "#BB7813", "#FF6158"),
+plot_font = "sans",
+font_face = "plain",
+target_fontface = "italic",
+font_size = 3.6,
+width = 0.05,
+alpha = 0.3,
+knot.pos = 0.3
+)
+
+TCM_sankey(...)
+```
+
+参数解析:
+- `data`: A data frame containing at least three columns: herb, molecule, and target.
+- `axis_order`: Character vector specifying the order of axes in the Sankey diagram. Default is c("herb", "molecule", "target").
+- `herb_cols`: Character vector defining the base color palette for the herb layer.
+- `mol_cols`: Character vector defining the base color palette for the molecule.
+- `target_cols`: Character vector defining the base color palette for the target.
+- `plot_font`: Character string specifying the font family used for text. Default is "sans".
+- `font_face`: Character string specifying the font face. Default is "plain".
+- `target_fontface`: Character string specifying the font face for target labels (rightmost axis). Default is "italic".
+- `font_size`: Numeric value controlling the size of node labels. Default is 3.5.
+- `width`: Numeric value controlling the width of both nodes and flows. Default is 0.05.
+- `alpha`: Numeric value controlling the transparency of the flows. Default is 0.3.
+- `knot.pos`: Numeric value (between 0 and 1) determining the curvature position of flow lines. Default is 0.3.
+- `...`: Additional arguments passed to tcm_sankey when using the deprecated alias TCM_sankey.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+tcm_sankey(
+data,
+axis_order = c("herb", "molecule", "target"),
+herb_cols = c("#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b",
+"#e377c2", "#7f7f7f"),
+mol_cols = c("#bcbd22", "#17becf", "#aec7e8", "#ffbb78", "#98df8a", "#ff9896",
+"#c5b0d5", "#E41A1C", "#377EB8"),
+target_cols = c("#c49c94", "#f7b6d2", "#dbdb8d", "#c7e9c0", "#f4cae4", "#e6f598",
+"#ffeda0", "#BB5234", "#BB7813", "#FF6158"),
+plot_font = "sans",
+font_face = "plain",
+target_fontface = "italic",
+font_size = 3.6,
+width = 0.05,
+alpha = 0.3,
+knot.pos = 0.3
+)
+
+TCM_sankey(...)
+```
+
+### `upsetplot()`
+
+UpSet plot for gene sets
+
+Convenience wrapper around aplotExtra::upset_plot() so the plot is
+directly available from TCMDATA. This is particularly useful for the output
+of get_ml_gene_sets().
+
+Usage:
+```r
+upsetplot(
+list,
+nintersects = NULL,
+order.intersect.by = c("size", "name"),
+order.set.by = c("size", "name"),
+color.intersect.by = "none",
+color.set.by = "none",
+remove_empty_intersects = TRUE
+)
+```
+
+参数解析:
+- `list`: A named list of gene sets.
+- `nintersects`: Number of intersections to show. NULL shows all.
+- `order.intersect.by`: One of "size" or "name".
+- `order.set.by`: One of "size" or "name".
+- `color.intersect.by`: Color scheme for intersection bars.
+- `color.set.by`: Color scheme for set bars.
+- `remove_empty_intersects`: Whether to remove empty intersections.
+
+使用示例:
+```r
+gene_sets <- list(
+LASSO = c("TP53", "BRCA1", "EGFR"),
+RF = c("TP53", "AKT1"),
+XGBOOST = c("EGFR", "AKT1", "MTOR")
+)
+upsetplot(gene_sets)
+```
+
+## Enrichment and pathway visualization
+
+### `ggdot_sankey()`
+
+Dot–Sankey plot for enrichment results
+
+Dot–Sankey plot for enrichment results
+
+Usage:
+```r
+ggdot_sankey(
+enrich_obj,
+n = 10,
+axis_order = c("Pathway", "Gene"),
+id_colors = c("#8DD3C7", "#FFFFB3", "#BEBADA", "#FB8072", "#80B1D3", "#FDB462",
+"#B3DE69", "#FCCDE5", "#D9D9D9", "#BC80BD", "#CCEBC5", "#FFED6F"),
+desc_colors = c("#E64B35", "#4DBBD5", "#00A087", "#3C5488", "#F39B7F", "#8491B4",
+"#91D1C2", "#C8DC96", "#7E6148", "#B09C85", "#6A5ACD", "#A0522D"),
+id_y_pos = 1.1,
+desc_y_pos = 1,
+pathway_wrap = 50,
+sankey_text_size = 4,
+bubble_size_range = c(3, 8),
+dot_palette = "RdBu",
+dot_x_var = c("GeneRatio", "RichFactor", "FoldEnrichment"),
+bubble_p_label = "p.adjust",
+sankey_width = 2,
+dot_width = 1,
+font_family = "sans",
+font_face = "plain",
+gene_fontface = "italic",
+sankey_lab = "Gene-Pathway",
+seed = 2025,
+...
+)
+```
+
+参数解析:
+- `enrich_obj`: enrichResult object or data.frame containing enrichment results.
+- `n`: Integer. The number of pathways to visualize (top n ranked by significance).
+- `axis_order`: Character vector of length 2, specifying the order of axes in
+the Sankey diagram. Default is c("Pathway", "Gene").
+- `id_colors`: Character vector of base colors for gene nodes.
+- `desc_colors`: Character vector of base colors for pathway nodes.
+- `id_y_pos`: Numeric constant controlling the y-position of “Gene” strata in the Sankey diagram. Default is 1.1.
+- `desc_y_pos`: Numeric constant controlling the y-position of “Pathway” strata in the Sankey diagram. Default is 1.0.
+- `pathway_wrap`: Integer. The maximum line width for pathway label wrapping. Default is 50.
+- `sankey_text_size`: Numeric. Font size for text labels in the Sankey diagram. Default is 4.
+- `bubble_size_range`: Numeric vector of length 2. Range of point sizes in the dot plot. Default is c(3, 8).
+- `dot_palette`: Character. Name of the RColorBrewer palette used for color gradients in the dot plot. Default is "RdBu".
+- `dot_x_var`: Character. Variable used for the x-axis in the dot plot.
+- `bubble_p_label`: Character. The column name for significance values used to color dotsd. Default is p.adjust.
+- `sankey_width`: Numeric. Relative width of the Sankey panel in the combined plot. Default is 2.
+- `dot_width`: Numeric. Relative width of the dot plot panel in the combined plot. Default is 1.
+- `font_family`: Character. Font family for all text elements. Default is "Arial".
+- `font_face`: Character. Font face for all text. Default is "plain".
+- `gene_fontface`: Character. Font face for gene labels (rightmost axis). Default is "italic".
+- `sankey_lab`: Character. Label for the x-axis of the Sankey diagram. Default is "Gene-Pathway".
+- `seed`: Integer. Random seed for reproducibility of layout. Default is 2025.
+- `...`: Additional arguments passed to internal helper functions.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+ggdot_sankey(
+enrich_obj,
+n = 10,
+axis_order = c("Pathway", "Gene"),
+id_colors = c("#8DD3C7", "#FFFFB3", "#BEBADA", "#FB8072", "#80B1D3", "#FDB462",
+"#B3DE69", "#FCCDE5", "#D9D9D9", "#BC80BD", "#CCEBC5", "#FFED6F"),
+desc_colors = c("#E64B35", "#4DBBD5", "#00A087", "#3C5488", "#F39B7F", "#8491B4",
+"#91D1C2", "#C8DC96", "#7E6148", "#B09C85", "#6A5ACD", "#A0522D"),
+id_y_pos = 1.1,
+desc_y_pos = 1,
+pathway_wrap = 50,
+sankey_text_size = 4,
+bubble_size_range = c(3, 8),
+dot_palette = "RdBu",
+dot_x_var = c("GeneRatio", "RichFactor", "FoldEnrichment"),
+bubble_p_label = "p.adjust",
+sankey_width = 2,
+dot_width = 1,
+font_family = "sans",
+font_face = "plain",
+gene_fontface = "italic",
+sankey_lab = "Gene-Pathway",
+seed = 2025,
+...
+)
+```
+
+### `gglollipop()`
+
+Lollipop Plot for Enrichment Results
+
+Lollipop Plot for Enrichment Results
+
+Usage:
+```r
+gglollipop(
+enrich_obj,
+x = "RichFactor",
+top_n = 10,
+orderBy = NULL,
+text.col = "black",
+text.size = 8,
+text.width = 35,
+palette = "RdBu",
+line.col = "grey60",
+line.type = "solid",
+line.size = 0.9,
+plot_title = NULL,
+show_count = TRUE,
+...
+)
+```
+
+参数解析:
+- `enrich_obj`: An enrichment result object from clusterProfiler.
+- `x`: Character. The variable used for the x-axis. Default is "RichFactor".
+- `top_n`: Integer. Number of top enriched terms to display. Default is 10.
+- `orderBy`: Character. Variable used to order the y-axis terms. Default is "x".
+- `text.col`: Character. Colors for text. Default is black.
+- `text.size`: Numeric. Font size for axis text and title. Default is 8.
+- `text.width`: Numeric. Font width for axis text and title. Default is 35.
+- `palette`: Character. Color palette name from RColorBrewer to use for dot color. Default is "RdBu".
+- `line.col`: Character. Color of the segment lines. Default is "grey60".
+- `line.type`: Character. Line type for segments. Default is "solid".
+- `line.size`: Numeric. Line width for segments. Default is 0.9.
+- `plot_title`: Character. Optional plot title. Default is NULL.
+- `show_count`: Logical. Whether to display the count value as a text label next to each dot. Default is TRUE
+- `...`: Additional arguments passed to internal helper functions.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+gglollipop(
+enrich_obj,
+x = "RichFactor",
+top_n = 10,
+orderBy = NULL,
+text.col = "black",
+text.size = 8,
+text.width = 35,
+palette = "RdBu",
+line.col = "grey60",
+line.type = "solid",
+line.size = 0.9,
+plot_title = NULL,
+show_count = TRUE,
+...
+)
+```
+
+### `go_barplot()`
+
+Bar Plot for GO Enrichment Results
+
+Create a bar plot for GO enrichment analysis results, with bars colored
+by ontology category (BP, CC, MF). Based on barplot method from enrichplot.
+
+Usage:
+```r
+go_barplot(
+enrich_obj,
+x = "Count",
+order = TRUE,
+top_n = 10,
+colors = NULL,
+label.size = 3.2,
+show_count = TRUE,
+label.bold = FALSE,
+x.angle = 60,
+legend.position = "top",
+plot_title = NULL,
+...
+)
+```
+
+参数解析:
+- `enrich_obj`: An enrichResult object from clusterProfiler::enrichGO().
+- `x`: Character. The variable to be plotted on the x-axis. Default is "Count".
+- `order`: Logical. Whether to sort x. Default is TRUE.
+- `top_n`: Integer. Number of top terms to display per ontology category. Default is 10.
+- `colors`: Named character vector for BP, CC, MF colors. Default is c(BP = "#E64B35", CC = "#4DBBD5", MF = "#00A087").
+- `label.size`: Numeric. Font size for count labels on bars. Default is 3.2.
+- `show_count`: Logical. Whether to show count labels on bars. Default is TRUE.
+- `label.bold`: Logical. Whether count labels should be bold. Default is FALSE.
+- `x.angle`: Numeric. Rotation angle of x-axis text (pathway descriptions). Default is 60.
+- `legend.position`: Character. Position of the legend. Default is "top".
+- `plot_title`: Character or NULL. Title of the plot. Default is NULL.
+- `...`: Additional parameters if neccessary.
+
+使用示例:
+```r
+## demo data
+herbs <- c("灵芝")
+lz <- search_herb(herb = herbs, type = "Herb_cn_name")
+set.seed(2025)
+g <- sample(lz$target, 200)
+
+## GO enrichment analysis
+library(clusterProfiler)
+x <- enrichGO(g, ont="all", OrgDb='org.Hs.eg.db', keyType="SYMBOL")
+p1 <- go_barplot(x)
+print(p1)
+```
+
+### `gocircle_plot()`
+
+GO circle plot
+
+Visualize GO enrichment results as a circular plot highlighting p.adjust,
+up/down-regulated genes, and RichFactor.
+
+Usage:
+```r
+gocircle_plot(
+x,
+top,
+up_genes = NULL,
+down_genes = NULL,
+cat_col = c(BP = "#E64B35", CC = "#4DBBD5", MF = "#00A087"),
+up_col = "#AE2A8A",
+down_col = "#7B87BF",
+padjust_col = c("#FF906F", "#861D30"),
+bg.col = "gray95",
+max_width = 2.5,
+fontsize = 8,
+fontface = "bold",
+fontfamily = "sans",
+...
+)
+```
+
+参数解析:
+- `x`: enrichResult object or data.frame from clusterProfiler.
+- `top`: Number of top terms to show per category.
+- `up_genes`: Vector of up-regulated genes (optional).
+- `down_genes`: Vector of down-regulated genes (optional).
+- `cat_col`: Named colors for GO categories (BP/CC/MF).
+- `up_col`: Colors for up-regulated gene bars.
+- `down_col`: Colors for down-regulated gene bars.
+- `padjust_col`: Gradient colors for -log10(p.adjust).
+- `bg.col`: Background color of outer ring.
+- `max_width`: Maximum width of up/down bars.
+- `fontsize`: Numeric. Font size for labels and legends.
+- `fontface`: Character. Font style, e.g. "plain", "bold", "italic".
+- `fontfamily`: Character. Font family, e.g. "sans", "serif", "mono".
+- `...`: Additional parameters for flexibility.
+
+使用示例:
+```r
+# Fill required arguments according to the parameter list above
+gocircle_plot(
+x,
+top,
+up_genes = NULL,
+down_genes = NULL,
+cat_col = c(BP = "#E64B35", CC = "#4DBBD5", MF = "#00A087"),
+up_col = "#AE2A8A",
+down_col = "#7B87BF",
+padjust_col = c("#FF906F", "#861D30"),
+bg.col = "gray95",
+max_width = 2.5,
+fontsize = 8,
+fontface = "bold",
+fontfamily = "sans",
+...
+)
+```
+
+### `herb_enricher()`
+
+A wrapper function of clusterProfiler::enricher() to do herb-target enrichment analysis.
+
+A wrapper function of clusterProfiler::enricher() to do herb-target enrichment analysis.
+
+Usage:
+```r
+herb_enricher(
+genes,
+bg_universe = NULL,
+type = c("Herb_pinyin_name", "Herb_cn_name", "Herb_en_name"),
+pvalueCutoff = 0.05,
+qvalueCutoff = 0.2,
+pAdjustMethod = "BH",
+minGSSize = 10,
+maxGSSize = 5000
+)
+```
+
+参数解析:
+- `genes`: Character vector. Query genes such as DEGs or disease targets.
+- `bg_universe`: Character vector or NULL. Background gene set. If NULL, defaults to all unique targets in TCMDATA.
+- `type`: Character. Specifies which column of tcm_data to use as herb names. Default is "Herb_pinyin_name".
+- `pvalueCutoff`: Numeric. P-value threshold for significance (default 0.05).
+- `qvalueCutoff`: Numeric. Q-value (FDR) threshold for significance (default 0.2).
+- `pAdjustMethod`: Character. Multiple testing correction method (default "BH").
+- `minGSSize`: Integer. Minimum herb gene-set size to include (default 10).
+- `maxGSSize`: Integer. Maximum herb gene-set size to include (default 5000).
+
+使用示例:
+```r
+library(enrichplot)
+data("dn_gcds")
+enrich_res <- herb_enricher(genes = dn_gcds, type = "Herb_pinyin_name")
+head(enrich_res)
+
+p <- dotplot(enrich_res)
+print(p)
+```
+
+### `interpret_enrichment()`
+
+Interpret enrichment analysis results with AI
+Uses a large language model to generate a structured interpretation of enrichment results (GO, KEGG, MSigDB, herb enrichment, etc.).
+
+Interpret enrichment analysis results with AI
+Uses a large language model to generate a structured interpretation of enrichment results (GO, KEGG, MSigDB, herb enrichment, etc.).
+
+Usage:
+```r
+interpret_enrichment(
+x,
+top_n = 10,
+max_genes = 5L,
+audience = "researcher",
+language = c("zh", "en"),
+role = NULL,
+system = NULL,
+prompt = NULL,
+model = NULL
+)
+```
+
+参数解析:
+- `x`: An enrichResult object or a data.frame with enrichment
+results.
+- `top_n`: Integer. Number of top terms to include. Default 10.
+- `max_genes`: Integer. Max genes shown per term in the compressed
+context. Default 5. Increase (e.g. 20) when you want the model
+to reason about the full gene list of specific terms.
+- `audience`: Character. Preset: "researcher",
+"wetlab", "paper". Or any free-text description
+like "clinical doctor unfamiliar with bioinformatics".
+- `language`: Character. "zh" or "en".
+Default "zh".
+- `role`: Character or NULL. The AI's identity / expertise description.
+Replaces the default "You are a bioinformatics expert..." opening
+line while keeping all other system-prompt constraints intact. Ignored
+when system is also provided (full override takes precedence).
+Example: "You are a TCM pharmacologist specialising in
+herb-target interactions.".
+- `system`: Character or NULL. Full system prompt override. Replaces
+the entire generated system prompt when provided (including role,
+audience, and language instructions).
+- `prompt`: Character or NULL. Custom user prompt instruction.
+Replaces the default instruction; the compressed data context
+is always appended.
+- `model`: A model identifier, LanguageModelV1 object, or NULL.
+
+使用示例:
+```r
+enrich_res <- herb_enricher(genes = my_genes)
+interpret_enrichment(enrich_res)
+
+# Custom role — keeps audience/language/constraints
+interpret_enrichment(enrich_res,
+role = "You are a TCM pharmacologist specialising in herb-target networks.")
+
+# Show more genes per term
+interpret_enrichment(enrich_res, max_genes = 20)
+```

--- a/inst/skills/tcm-network-pharmacology/references/package-sections.md
+++ b/inst/skills/tcm-network-pharmacology/references/package-sections.md
@@ -1,0 +1,188 @@
+# TCMDATA Documentation Section Map
+
+Use this file to ensure every package documentation section is represented when planning or answering network pharmacology tasks. Only execute sections explicitly requested by the user.
+
+## 01-Load-TCM-Data.Rmd - Load TCM Data {#load-data}
+
+- Search by herb name
+- Using Pinyin format
+- Search by target gene
+- Session information
+
+## 02-Pre-analysis.Rmd - Pre-analysis {#pre-analysis}
+
+- PubMed literature mining
+- Visualization
+- Exporting results
+- Herb enrichment analysis {#herb-ora}
+- Example: Diabetic Nephropathy
+- References
+- Session information
+
+## 03-Molecule-detection.Rmd - Molecule annotation {#molecule-detection}
+
+- Resolving compound identifiers
+- Using `resolve_cid()`
+- Using `getcid()`
+- Retrieving chemical properties
+- Similarity searching
+- Download molecular structures and format conversion
+- Downloading ligand structures from PubChem
+- Downloading receptor structures from the RCSB PDB
+- Converting structure file formats
+- References
+- Session information
+
+## 04-Target-retrieval-analysis.Rmd - Target retrieval and DEG analysis {#target-retrieval}
+
+- Programmatic disease target retrieval with TCMDATA {#disease-target-tcmdata}
+- `search_disease()`: disease → genes
+- `search_gene_disease()`: gene → diseases
+- Disease target databases {#disease-db}
+- GeneCards
+- Open Targets Platform
+- CTD (Comparative Toxicogenomics Database)
+- Other databases
+- Compound target prediction {#compound-target}
+- SwissTargetPrediction {#compound-target-swisstarget}
+- Similarity Ensemble Approach (SEA)
+- DEG visualization{#volcano}
+- Load and inspect data
+- Volcano plot with `ivolcano`
+- Intersection analysis {#intersection}
+- Prepare gene sets
+- Venn diagram
+- UpSet plot
+- Extract intersection results
+- References
+- Session information
+
+## 05-TCM-network-construction.Rmd - TCM network construction {#network-construction}
+
+- Preparing the data
+- Sankey diagram visualization
+- Basic usage
+- Customizing colors and appearance
+- Network graph with `ggtangle`
+- Building the graph
+- Basic network visualization
+- Adding node labels
+- Alternative layouts
+- Enriching the network with external data
+- References
+- Session information
+
+## 06-Enrichment-analysis.Rmd - Enrichment analysis {#enrichment}
+
+- Over Representation Analysis (ORA)
+- KEGG enrichment analysis
+- GO enrichment analysis
+- Advanced visualization
+- Lollipop plot
+- Dot-sankey plot
+- GO bar plot
+- GO circle plot
+- Gene Set Enrichment Analysis (GSEA)
+- Prepare ranked gene list
+- KEGG GSEA analysis
+- GO GSEA analysis
+- Session information
+
+## 07-PPI-analysis.Rmd - PPI network analysis {#ppi-analysis}
+
+- Retrieving PPI data from STRING
+- Network filtering
+- Topological metrics {#topology}
+- Integrated ranking
+- Radar plot of topological metrics
+- Heatmap of topological metrics
+- Community detection {#clustering}
+- Louvain modularity optimization
+- MCODE (Molecular Complex Detection)
+- MCL (Markov Clustering)
+- Fast greedy modularity optimization
+- PPI network robustness analysis {#robustness}
+- Algorithm overview
+- Example: knocking out IL6
+- Visualization: before vs. after knockout
+- PPI network visualization {#ppi-vis}
+- Basic network with topological mapping
+- Community-colored network
+- Hub-centric star layout
+- Layout algorithm comparison
+- References
+- Session information
+
+## 08-Machine-Learning-analysis.Rmd - Machine learning–based key target screening {#ml-analysis}
+
+- Introduction
+- Example dataset {#ml-data}
+- Data preparation {#ml-prepare}
+- Mode A: full cross-validation {#ml-mode-a}
+- LASSO regression {#ml-lasso}
+- CV error curve
+- Coefficient path
+- Coefficient bar chart
+- Random Forest and Boruta {#ml-rf}
+- Boruta importance plot
+- Variable importance (Gini)
+- SVM-RFE {#ml-svm-rfe}
+- RFE accuracy profile
+- XGBoost {#ml-xgboost}
+- Feature importance (Gain)
+- Consensus analysis {#ml-consensus}
+- Running all methods together
+- Venn diagram
+- Extracting consensus genes
+- ROC curves
+- Mode B: internal train/test split {#ml-mode-b}
+- Mode C: external validation {#ml-mode-c}
+- Post-hoc feature trimming {#ml-select}
+- Assembling models manually {#ml-manual-list}
+- Single-gene diagnostic analysis {#ml-gene-diag}
+- AUC summary table
+- Single-gene ROC curves
+- Two-group expression boxplot
+- Summary {#ml-summary}
+- References
+- Session Information {#ml-session-info}
+
+## 09-AI-module.Rmd - AI Module {#ai-module}
+
+- Prerequisites
+- Interpretation layer
+- Free-text interpretation
+- Interpreting enrichment objects
+- Interpreting PPI objects
+- Drafting result paragraphs
+- Custom structured output
+- Agent layer
+- One-shot task: `tcm_agent()`
+- Interactive session: `tcm_chat()`
+- Programmatic agent: `create_tcm_task_agent()`
+- Artifact management
+- Skill layer
+- Built-in skills
+- How skills work
+- Creating custom skills
+- Managing skills
+- Session information
+
+## 10-Other-resources.Rmd - Other resources {#other-resources}
+
+- Additional databases
+- TF–gene interactions (DoRothEA)
+- Application example
+- Gut microbiota–host interactions (GutMGene)
+- Application example: Gut–TCM integration
+- Network visualization with ggtangle
+- Additional visualization
+- Heatmap for molecular docking results
+- To be continued
+- References
+- Session information
+
+## index.Rmd - Preface {-}
+
+- Installation {-}
+

--- a/inst/skills/tcm-network-pharmacology/references/plotting-style.md
+++ b/inst/skills/tcm-network-pharmacology/references/plotting-style.md
@@ -1,0 +1,188 @@
+# TCMDATA Plotting Style
+
+Use this file when producing report-ready R figures from TCMDATA results. The goal is a clean scientific figure with a clear biological message, not decorative complexity.
+
+## Figure Contract
+
+Before plotting, define:
+
+1. Claim: one sentence describing what the figure should show.
+2. Evidence: the object being plotted, such as KEGG terms, PPI hub ranking, ML features, or docking scores.
+3. Audience: exploratory notebook, report, manuscript, or slide.
+4. Output: object only, current R environment assignment, or saved PNG/PDF/SVG.
+
+## Global R Theme
+
+Use this as the default style unless the user supplies a theme.
+
+```r
+library(ggplot2)
+
+tcm_pub_theme <- function(base_size = 7, base_family = "Arial") {
+  theme_classic(base_size = base_size, base_family = base_family) +
+    theme(
+      axis.line = element_line(linewidth = 0.35, colour = "black"),
+      axis.ticks = element_line(linewidth = 0.35, colour = "black"),
+      axis.text = element_text(colour = "black"),
+      legend.title = element_text(size = base_size * 0.9),
+      legend.text = element_text(size = base_size * 0.85),
+      strip.background = element_blank(),
+      strip.text = element_text(face = "bold"),
+      plot.title = element_text(face = "bold", hjust = 0),
+      plot.subtitle = element_text(colour = "grey30"),
+      panel.grid = element_blank()
+    )
+}
+```
+
+## Palette
+
+Use restrained, low-saturation colors with one accent for the main signal.
+
+```r
+tcm_cols <- c(
+  herb = "#5D8A66",
+  compound = "#C49A4A",
+  target = "#4E79A7",
+  disease = "#B85C5C",
+  neutral = "#6F6F6F",
+  light = "#D9DEE7"
+)
+```
+
+Rules:
+
+- Do not use rainbow palettes for enrichment or hub rankings.
+- Use red only for highlighted key targets, risk, or stronger signal.
+- Use color and size redundantly for enrichment plots: color for adjusted p-value, size for gene count or ratio.
+- Keep labels sparse. Label top terms, hub genes, or user-requested genes only.
+
+## Enrichment Plots
+
+### Dot or scatter plot
+
+Use a dot plot when the user asks for scatter/dot visualization of KEGG or GO results.
+
+```r
+df <- as.data.frame(kegg)
+df <- df[order(df$p.adjust), ][seq_len(min(10, nrow(df))), ]
+df$Description <- factor(df$Description, levels = rev(df$Description))
+
+p_kegg <- ggplot(df, aes(x = GeneRatio, y = Description)) +
+  geom_point(aes(size = Count, colour = p.adjust), alpha = 0.9) +
+  scale_colour_gradient(low = "#B85C5C", high = "#4E79A7", name = "Adjusted P") +
+  scale_size_continuous(name = "Gene count", range = c(2, 6)) +
+  labs(x = "Gene ratio", y = NULL, title = "KEGG enrichment") +
+  tcm_pub_theme()
+```
+
+If `GeneRatio` is stored as `"x/y"`, convert it before plotting:
+
+```r
+ratio_to_num <- function(x) vapply(strsplit(as.character(x), "/"), function(z) as.numeric(z[1]) / as.numeric(z[2]), numeric(1))
+df$GeneRatio <- ratio_to_num(df$GeneRatio)
+```
+
+### Lollipop plot
+
+Use `gglollipop()` for compact ranked pathway views.
+
+```r
+p_go <- gglollipop(go_bp, showCategory = 10) + tcm_pub_theme()
+```
+
+### Bar plot
+
+Use bars for a single metric such as `-log10(p.adjust)`.
+
+```r
+df$neg_log10_p <- -log10(df$p.adjust)
+p_bar <- ggplot(df, aes(x = neg_log10_p, y = Description)) +
+  geom_col(fill = tcm_cols["target"], width = 0.68) +
+  labs(x = "-log10 adjusted P", y = NULL) +
+  tcm_pub_theme()
+```
+
+## PPI Plots
+
+### Hub heatmap
+
+Use a heatmap for comparing centrality metrics across top hub genes.
+
+```r
+p_heat <- plot_node_heatmap(hub_rank, top_n = 10)
+```
+
+### Radar plot
+
+Use radar plots only for one to three genes. For more genes, prefer heatmaps.
+
+```r
+profile <- get_node_profile(hub_rank, node_name = "TNF")
+p_radar <- radar_plot(profile)
+```
+
+### Network plot
+
+For network graphs, map:
+
+- node size to degree or hub score
+- node color to type or community
+- label to top hubs only
+- edge alpha to confidence score
+
+Avoid plotting hundreds of labels. Filter or facet by community when a network is dense.
+
+## Machine Learning Plots
+
+Use the model-specific plotting functions first:
+
+```r
+p_lasso_cv <- plot_enet_cv(fit_lasso)
+p_lasso_coef <- plot_enet_coefs(fit_lasso, top_n = 20)
+p_rf <- plot_rf_importance(fit_rf, top_n = 20)
+p_svm <- plot_svm_rfe_curve(fit_svm)
+p_xgb <- plot_xgb_importance(fit_xgb, top_n = 20)
+p_venn <- plot_ml_venn(ml_all)
+p_roc <- plot_ml_roc(ml_all)
+```
+
+For diagnostic gene plots:
+
+```r
+p_gene_roc <- plot_gene_roc(genes = c("TNF", "IL6"), expr_mat = expr, group = group)
+p_gene_box <- plot_gene_boxplot(genes = c("TNF", "IL6"), expr_mat = expr, group = group)
+```
+
+## Docking Heatmaps
+
+Use `ggdock()` for ligand-target score matrices. Cluster rows/columns only when the figure remains interpretable.
+
+```r
+p_dock <- ggdock(docking_matrix)
+```
+
+## Saving
+
+When the user asks to save a plot to the current R environment, assign it exactly:
+
+```r
+assign("p_kegg", p_kegg, envir = .GlobalEnv)
+```
+
+When the user asks for files, save both PNG and PDF unless they specify one format.
+
+```r
+ggsave("p_kegg.png", p_kegg, width = 7, height = 4.8, dpi = 300)
+ggsave("p_kegg.pdf", p_kegg, width = 7, height = 4.8)
+```
+
+For manuscript figures, prefer PDF/SVG with editable text and 300-600 dpi raster output when required.
+
+## Quality Checks
+
+- Axis text must be readable without rotation unless long pathway names require wrapping.
+- Pathway descriptions should be ordered by adjusted p-value or gene ratio.
+- Legends must explain color and size encodings.
+- Empty enrichment results should not be plotted; report the empty result and suggest ID conversion or relaxed thresholds.
+- Figures should be reproducible from named objects, not only displayed interactively.

--- a/inst/skills/tcm-network-pharmacology/references/workflow.md
+++ b/inst/skills/tcm-network-pharmacology/references/workflow.md
@@ -1,357 +1,417 @@
-# TCM Network Pharmacology — Unified Workflow
+# TCMDATA Network Pharmacology Workflow
 
-Complete analysis pipeline from herb/disease input through multi-omics validation.
-Covers standard (database-only), expression-enhanced (RNA-seq/DEGs), WGCNA, single-cell, and ML workflows.
+Use this file to plan and execute TCMDATA tasks. It covers every package documentation section, but the scope rule remains: execute only what the user requested.
 
-> **Scope rule**: This document describes the FULL pipeline. Only execute phases the user actually asks for. For a simple herb target query, run Phase 1 Step 1 only. For a single enrichment, run only that step. Execute all phases only when the user explicitly requests a complete or systematic analysis.
+## 0. Setup and Documentation Coverage
 
----
+Install and load TCMDATA before analysis:
 
-## Phase 0: Data Reconnaissance (Optional but Recommended)
-
-Before starting analysis, help the user discover relevant public datasets.
-
-### Step 0a: Search GEO for RNA-seq / Microarray Datasets
-
-```
-geo_result <- search_geo_datasets(
-  disease = [disease_name],
-  organism = "Homo sapiens",
-  max_results = 20
-)
-```
-
-Present results as a table: GSE accession, title, platform, sample count, summary.
-Let the user choose which dataset(s) to use for downstream analysis.
-
-**When to suggest this step:**
-- User asks about a specific disease but hasn't provided expression data
-- User mentions "GEO", "dataset", "transcriptome", or "expression profile"
-- At the start of any analysis, proactively mention: "I found N relevant GEO datasets for [disease]. Would you like to incorporate expression data?"
-
-### Step 0b: Search GEO for Single-Cell Datasets
-
-```
-geo_sc_result <- search_geo_datasets(
-  disease = [disease_name],
-  organism = "Homo sapiens",
-  dataset_type = "single-cell",
-  max_results = 10
-)
-```
-
-Single-cell datasets can be used for cell-type-level validation in Phase 4.
-
----
-
-## Phase 1: Target Collection
-
-### Step 1: Herb Target Retrieval
-
-```
-herb_result <- search_herb_records(herb = [herb_names], type = [auto-detect])
-herb_targets <- unique(herb_result$target)
-```
-
-Auto-detect type:
-- Contains Chinese characters → `"Herb_cn_name"`
-- Capitalized English → `"Herb_pinyin_name"`
-- Lowercase English → `"Herb_en_name"`
-
-If multiple herbs (a formula), combine all targets:
-```
-herb_result <- search_herb_records(herb = c("黄芪", "当归", "甘草"), type = "Herb_cn_name")
-herb_targets <- unique(herb_result$target)
-```
-
-Report: "[N] targets found for [herb(s)] from TCMDATA database (source: TCMSP/SymMap)"
-
-### Step 2: Disease Target Retrieval
-
-```
-disease_result <- search_disease_targets(disease = [disease_name])
-disease_genes <- unique(disease_result$symbol)
-```
-
-For ambiguous disease names, try the most specific term first. If results are too few (< 50 genes), try broader terms.
-
-Report: "[N] disease-associated genes found for [disease] from DisGeNET"
-
-### Step 3: Target Intersection
-
-**Mode A — Standard (two-way intersection):**
-```
-intersection <- compute_target_intersection(
-  gene_lists = list(herb_targets, disease_genes),
-  set_names = c("[Herb] Targets", "[Disease] Targets")
-)
-common_targets <- intersection$intersection
-```
-
-**Mode B — Expression-enhanced (three-way intersection, with DEGs):**
-```
-intersection <- compute_target_intersection(
-  gene_lists = list(herb_targets, disease_genes, deg_list),
-  set_names = c("[Herb] Targets", "[Disease] Genes", "DEGs")
-)
-common_targets <- intersection$intersection
-```
-
-**Mode C — WGCNA-enhanced (three-way intersection, with WGCNA hub genes):**
-```
-intersection <- compute_target_intersection(
-  gene_lists = list(herb_targets, disease_genes, wgcna_hub_genes),
-  set_names = c("[Herb] Targets", "[Disease] Genes", "WGCNA Hub Genes")
-)
-common_targets <- intersection$intersection
-```
-
-**Mode D — Multi-source (four-way intersection):**
-When both DEGs and WGCNA results are available:
-```
-intersection <- compute_target_intersection(
-  gene_lists = list(herb_targets, disease_genes, deg_list, wgcna_hub_genes),
-  set_names = c("[Herb] Targets", "[Disease] Genes", "DEGs", "WGCNA Hub Genes")
-)
-common_targets <- intersection$intersection
-```
-
-**Decision points:**
-- `length(common_targets) < 5`: Warn user. Suggest relaxing parameters or using two-way intersection instead.
-- `length(common_targets) > 500`: Suggest narrowing disease scope or selecting specific herbs.
-- `5 ≤ length(common_targets) ≤ 500`: Proceed normally.
-
-Report: "[N] common targets at the intersection"
-
----
-
-## Phase 2: Network & Enrichment Analysis
-
-### Step 4: PPI Network Construction
-
-```
-ppi <- get_ppi_network(genes = common_targets, score_threshold = 400)
-metrics <- compute_ppi_metrics(artifact_id = ppi$artifact_id)
-hub_genes <- rank_ppi_nodes(artifact_id = metrics$artifact_id, top_n = 10)
-```
-
-If PPI returns very few edges (< 10), try lowering score_threshold to 150.
-
-Report: "PPI network: [N] nodes, [M] edges; Top hub genes: [list]"
-
-### Step 5: Functional Enrichment
-
-Run both GO-BP and KEGG on the intersection genes (NOT on herb targets or disease targets alone):
-
-```
-go_result <- run_go_enrichment(genes = common_targets, ontology = "BP")
-kegg_result <- run_kegg_enrichment(genes = common_targets)
-```
-
-Report top 5 significant terms (p.adjust < 0.05) for each.
-
-### Step 6: Visualization
-
-Generate publication-ready figures in this order:
-1. `plot_herb_sankey` — Herb-Compound-Target network (use herb artifact)
-2. `plot_ppi_result(type = "heatmap")` — Hub gene topology metrics
-3. `plot_enrichment_result(type = "lollipop")` — GO/KEGG lollipop plot
-
----
-
-## Phase 3: Expression-Based Validation (When Expression Data Available)
-
-Skip this phase entirely if user has no expression data / DEG list / expression matrix.
-
-### Step 7a: WGCNA Module Analysis
-
-**When to use:** User has expression matrix with ≥ 15 samples per group.
-
-WGCNA identifies co-expression modules correlated with the disease phenotype. The hub genes of key modules serve as an independent gene set for intersection.
-
-Recommended workflow (user runs in R with guidance):
 ```r
-# Recommend the user to perform WGCNA using the WGCNA package:
-# 1. Construct weighted adjacency matrix
-# 2. Identify modules via dynamic tree cut
-# 3. Correlate modules with clinical traits
-# 4. Extract hub genes from key module(s) (module membership > 0.8, gene significance > 0.2)
-
-# The agent should guide these parameter choices:
-# - softPower: use pickSoftThreshold() to determine
-# - minModuleSize: 30 (default)
-# - mergeCutHeight: 0.25 (default)
-# - Module selection: choose module(s) with highest |correlation| to disease trait
-
-# After WGCNA, user provides the hub gene list:
-wgcna_hub_genes <- [user_provided_list]
+library(TCMDATA)
 ```
 
-**Integration with network pharmacology:**
-- Use `wgcna_hub_genes` in Phase 1 Step 3 (Mode C or D) for intersection
-- WGCNA hub genes that overlap with herb targets are high-confidence therapeutic targets
-- Report module color, module-trait correlation, and number of hub genes extracted
+Use `package-sections.md` as the section checklist. Use `function-reference.md` for exact function parameters and examples.
 
-### Step 7b: ML Feature Selection
+## 1. Load TCM Data
 
-**When to use:** User has expression matrix with group labels (e.g. disease vs control).
+### Search by herb name
 
+Use `search_herb()` for herb-compound-target records.
+
+```r
+huangqi <- search_herb("黄芪", type = "Herb_cn_name")
+targets <- unique(huangqi$target)
 ```
-ml_data <- prepare_ml_dataset(
-  expr_matrix = [expression_matrix],
-  group = [group_labels],
-  gene_filter = common_targets  # restrict to intersection genes
+
+Name-type rule:
+
+- Chinese characters: `type = "Herb_cn_name"`
+- Continuous Pinyin, such as `Huangqi`: `type = "Herb_pinyin_name"`
+- English/common lowercase names: `type = "Herb_en_name"`
+
+Avoid spaces or hyphens in pinyin queries unless the database explicitly stores them.
+
+### Search by target gene
+
+Use `search_target()` when the user starts from genes.
+
+```r
+tnf_records <- search_target(c("TNF", "IL6", "AKT1"))
+```
+
+## 2. Pre-Analysis
+
+### PubMed literature mining
+
+Use PubMed before or after the computational analysis when the user asks for evidence, references, publication trends, or result interpretation.
+
+```r
+pubmed <- get_pubmed_data(tcm_name = "Huangqi", disease = "diabetic nephropathy")
+plot(pubmed)
+tbl <- get_pubmed_table(pubmed, n = 10)
+```
+
+### Herb enrichment analysis
+
+Use `herb_enricher()` when the user provides genes and asks which herbs are enriched.
+
+```r
+genes <- c("TNF", "IL6", "AKT1", "VEGFA", "TP53")
+herb_or <- herb_enricher(genes)
+```
+
+## 3. Molecule Annotation
+
+### Resolve compound identifiers
+
+Use `resolve_cid()` for direct PubChem identifier resolution and `getcid()` for the webchem-backed alternative.
+
+```r
+cid_tbl <- resolve_cid(c("quercetin", "kaempferol"), from = "name")
+cid_alt <- getcid(c("quercetin", "kaempferol"))
+```
+
+### Retrieve chemical properties
+
+Use `getprops()` after resolving CIDs.
+
+```r
+props <- getprops(cid_tbl$cid)
+```
+
+### Similarity searching
+
+Use `compound_similarity()` for 2D structural similarity.
+
+```r
+similar <- compound_similarity(query = 5280343, threshold = 0.8)
+```
+
+### Download structures and convert formats
+
+Use PubChem for ligands and RCSB PDB for receptors. Convert structures before docking when needed.
+
+```r
+sdf <- download_ligand_structure(cid = 5280343, format = "SDF")
+pdb <- download_receptor_structure(pdb_id = "1A2B")
+ligand_pdb <- convert_structure(sdf, output_format = "pdb")
+```
+
+## 4. Target Retrieval and DEG Analysis
+
+### Programmatic disease target retrieval
+
+Use `search_disease()` for disease to gene queries and `search_gene_disease()` for gene to disease queries.
+
+```r
+dn <- search_disease("diabetic nephropathy")
+tnf_diseases <- search_gene_disease("TNF")
+```
+
+If the disease name is ambiguous, try a more specific term first. If fewer than 50 genes return, try a broader disease term or exact CUI if available.
+
+### External disease target databases
+
+When the user brings GeneCards, Open Targets, CTD, SwissTargetPrediction, or SEA results, import them as additional gene sets and keep their source labels. Do not mix evidence sources without naming them.
+
+```r
+gene_sets <- list(
+  TCMDATA_herb = unique(huangqi$target),
+  DisGeNET_disease = unique(dn$symbol),
+  GeneCards = genecards_genes
 )
-ml_result <- run_ml_screening(artifact_id = ml_data$artifact_id)
-consensus <- get_ml_consensus(artifact_id = ml_result$artifact_id, min_methods = 2)
 ```
 
-The consensus genes are the final "key targets" with both network pharmacology supporting and ML validation.
+### DEG visualization
 
-Add ML-specific plots:
-```
-plot_ml_result(type = "venn")   # ML method overlap
-plot_ml_result(type = "roc")    # ROC curves for top genes
-```
+When the user provides DEG output, filter and visualize by the documented cutoffs unless they specify different thresholds.
 
-### Step 7c: DEG Analysis Integration
-
-**When to use:** User provides a DEG list (e.g. from limma/DESeq2 on GEO data).
-
-- Use DEG list directly in Phase 1 Step 3 (Mode B) for three-way intersection
-- DEG direction (up/down) can further refine biological interpretation
-- If user has full DESeq2/limma results, suggest filtering: |log2FC| > 1, adj.p < 0.05
-
----
-
-## Phase 4: Single-Cell Validation (When scRNA-seq Data Available)
-
-Skip this phase entirely if no single-cell data is available.
-
-### Step 8: Single-Cell Analysis for Target Validation
-
-**Purpose:** Validate hub genes / key targets at single-cell resolution — confirm cell-type-specific expression patterns.
-
-**Recommended packages** (guide user to use in their R session):
-
-1. **Seurat** (most common):
 ```r
-# Standard Seurat workflow:
-library(Seurat)
-obj <- CreateSeuratObject(counts = counts_matrix)
-obj <- NormalizeData(obj) %>% FindVariableFeatures() %>% ScaleData() %>% RunPCA()
-obj <- FindNeighbors(obj) %>% FindClusters() %>% RunUMAP()
-
-# Validate hub genes at cell-type level:
-FeaturePlot(obj, features = hub_genes[1:4])
-DotPlot(obj, features = hub_genes, group.by = "cell_type")
-VlnPlot(obj, features = hub_genes[1:4], group.by = "cell_type")
-
-# Differential expression in specific cell types:
-markers <- FindMarkers(obj, ident.1 = "disease", ident.2 = "control",
-                       subset.ident = "target_cell_type")
+deg_sig <- subset(deg, abs(log2FoldChange) > 1 & padj < 0.05)
 ```
 
-2. **SingleCellExperiment / Bioconductor ecosystem**:
+### Intersection analysis
+
+Use `getvenndata()` and `getvennresult()` for Venn-style intersections, `ggvenn_plot()` for Venn plots, and `upsetplot()` for larger set combinations.
+
 ```r
-library(SingleCellExperiment)
-library(scater)
-library(scran)
-sce <- SingleCellExperiment(assays = list(counts = counts_matrix))
-sce <- logNormCounts(sce)
-sce <- runPCA(sce) %>% runUMAP()
-
-# Validate targets:
-plotExpression(sce, features = hub_genes, x = "cell_type")
+venn_df <- getvenndata(
+  Herb = unique(huangqi$target),
+  Disease = unique(dn$symbol)
+)
+common_targets <- getvennresult(venn_df, category = c("Herb", "Disease"))
+p_intersection <- ggvenn_plot(venn_df)
 ```
 
-3. **sclet** (lightweight alternative):
-Details can be found at: https://github.com/YuLab-SMU/sclet
+Decision points:
+
+- Fewer than 5 common targets: warn and suggest broader terms or relaxed filters.
+- More than 500 common targets: suggest narrowing the disease, herb, or evidence source.
+- For herb-disease mechanism claims, use common targets downstream.
+
+## 5. TCM Network Construction
+
+### Prepare herb-compound-target data
+
+Use a clear edge table with source, target, and node type.
+
 ```r
-library(sclet)
-# Follow sclet workflow for QC, normalization, clustering
-# Validate hub gene expression across cell types
+graph_data <- prepare_herb_graph(huangqi)
 ```
 
-**Integration with network pharmacology results:**
-- Check which cell types express the hub genes most strongly
-- Verify that key pathway genes (from KEGG enrichment) are active in disease-relevant cell types
-- Cell-type-specific expression adds biological depth to the network pharmacology findings
-- Report: "Hub gene [X] is highly expressed in [cell_type], consistent with [pathway] enrichment"
+### Sankey diagram
 
----
+Use `tcm_sankey()` for herb-compound-target flows.
 
-## Phase 5: Validation & Reporting
-
-### Step 9: Literature Validation
-
-```
-pubmed <- get_pubmed_evidence(herb = [herb_pinyin], disease = [disease_en], max_results = 20)
+```r
+p_sankey <- tcm_sankey(huangqi)
 ```
 
-Summarize: how many papers, publication trend, key findings from abstracts.
+### Network graph
 
-### Step 10: External Cross-Validation
+When the user asks for graph visualization, use `ggtangle` if available and keep node type, degree, or centrality visible.
 
-```
-urls <- generate_verification_urls(herbs = [herb_names], targets = hub_genes, disease = [disease])
-```
+Recommended mapping:
 
-Provide HERB database and ShenNong Alpha links for user to cross-check key findings.
+- Herb: muted green
+- Compound: muted amber
+- Target: muted blue
+- Key/hub target: restrained red accent
 
-### Step 11: Compound-Target Molecular Docking (Optional)
+## 6. Enrichment Analysis
 
-If user requests docking or molecular validation:
-```
-cid <- resolve_compound_cid(identifier = [compound_name])
-props <- get_compound_properties(cid = cid)
-```
+### Over-representation analysis
 
-Report on druglikeness (Lipinski's Rule of Five from properties).
+For TCMDATA herb enrichment, use `herb_enricher()`. For GO/KEGG ORA, use `clusterProfiler` with explicit gene ID conversion.
 
-### Step 12: Interpretation & Report
+```r
+library(clusterProfiler)
+library(org.Hs.eg.db)
 
-Call `interpret_artifact` on:
-1. The enrichment result (GO)
-2. The PPI hub gene ranking
-3. The KEGG result
-
-Synthesize into the report template defined in SKILL.md.
-
----
-
-## Workflow Decision Tree
-
-```
-User Input → Herb + Disease
-  │
-  ├─ Phase 0: Search GEO for relevant datasets (recommend to user)
-  │
-  ├─ Phase 1: Collect targets → Intersection
-  │   ├─ No expression data → Two-way intersection (Mode A)
-  │   ├─ Has DEGs → Three-way intersection (Mode B)
-  │   ├─ Has WGCNA hub genes → Three-way intersection (Mode C)
-  │   └─ Has DEGs + WGCNA → Four-way intersection (Mode D)
-  │
-  ├─ Phase 2: PPI + Enrichment (always)
-  │
-  ├─ Phase 3: Expression validation (if data available)
-  │   ├─ WGCNA → Module hub genes
-  │   ├─ ML screening → Consensus biomarkers
-  │   └─ DEG integration → Direction-aware filtering
-  │
-  ├─ Phase 4: Single-cell validation (if scRNA-seq available)
-  │   └─ Cell-type-specific expression of hub genes
-  │
-  └─ Phase 5: Literature + Cross-validation + Report
+gene_map <- bitr(common_targets, fromType = "SYMBOL", toType = "ENTREZID", OrgDb = org.Hs.eg.db)
+kegg <- enrichKEGG(gene = gene_map$ENTREZID, organism = "hsa", pvalueCutoff = 0.05)
+go_bp <- enrichGO(gene = gene_map$ENTREZID, OrgDb = org.Hs.eg.db, ont = "BP",
+                  pvalueCutoff = 0.05, qvalueCutoff = 0.2, readable = TRUE)
 ```
 
-## Phase Selection Guide
+### Advanced visualization
 
-| User has | Phases to run | Intersection mode |
-|----------|--------------|-------------------|
-| Herb + Disease only | 0→1→2→5 | Mode A (two-way) |
-| + DEG list | 0→1→2→3c→5 | Mode B (three-way) |
-| + Expression matrix | 0→1→2→3a→3b→5 | Mode C or D |
-| + scRNA-seq data | 0→1→2→(3)→4→5 | Mode A/B/C/D |
-| Full multi-omics | 0→1→2→3→4→5 | Mode D (four-way) |
+Use:
+
+- `gglollipop()` for ranked enrichment terms.
+- `ggdot_sankey()` for term-gene dot-sankey views.
+- `go_barplot()` for GO bar plots.
+- `gocircle_plot()` after preparing fold-change data with `getGores()`.
+
+```r
+p_kegg <- gglollipop(kegg, showCategory = 10)
+p_go <- go_barplot(go_bp, showCategory = 10)
+```
+
+### GSEA
+
+Use GSEA only when the user provides a ranked gene list, such as named logFC scores.
+
+```r
+gene_list <- sort(setNames(deg$log2FoldChange, deg$SYMBOL), decreasing = TRUE)
+```
+
+## 7. PPI Network Analysis
+
+### Retrieve and filter PPI data
+
+Use STRING through `get_ppi()` and filter with `ppi_subset()` when the user asks for confidence filtering or top interactions.
+
+```r
+ppi <- get_ppi(common_targets, taxID = 9606)
+ppi_filtered <- ppi_subset(ppi, score_threshold = 400)
+```
+
+### Topological metrics and integrated ranking
+
+Use `compute_nodeinfo()` and `rank_ppi_nodes()`.
+
+```r
+ppi_metrics <- compute_nodeinfo(ppi_filtered, weight_attr = "score")
+hub_rank <- rank_ppi_nodes(ppi_metrics, top_n = 10)
+```
+
+### Radar and heatmap
+
+Use `get_node_profile()` + `radar_plot()` for individual hub genes and `plot_node_heatmap()` for topological metrics.
+
+```r
+profile <- get_node_profile(hub_rank, node_name = hub_rank$name[1])
+p_radar <- radar_plot(profile)
+p_heatmap <- plot_node_heatmap(hub_rank)
+```
+
+### Community detection
+
+Use community methods based on the question:
+
+- `run_louvain()` for modularity-based communities.
+- `run_mcode()` / `runMCODE()` for dense molecular complexes.
+- `run_MCL()` for flow-based modules.
+- `run_fastgreedy()` for fast modularity clustering.
+- `add_cluster_score()` to rank clusters.
+
+### Robustness analysis
+
+Use `ppi_knock()` to simulate removal of hub genes or target sets.
+
+```r
+robust <- ppi_knock(ppi_filtered, targets = hub_rank$name[1])
+```
+
+### PPI visualization
+
+Use topology mapping, community coloring, hub-centric layouts, or layout comparisons according to the user request. Keep labels sparse; label only top hubs unless the network is small.
+
+## 8. Machine Learning-Based Key Target Screening
+
+### Data preparation
+
+Use expression matrix rows as genes and columns as samples. Group labels must match sample order.
+
+```r
+ml_data <- prepare_ml_data(expr_mat = expr, group = group, gene_filter = common_targets)
+```
+
+### Mode A: full cross-validation
+
+Run all supported methods when the user asks for comprehensive screening.
+
+```r
+ml_all <- run_ml_screening(ml_data)
+consensus <- get_ml_consensus(ml_all, min_methods = 2)
+```
+
+### Individual methods
+
+Use individual methods when requested:
+
+```r
+fit_lasso <- ml_lasso(ml_data)
+fit_enet <- ml_enet(ml_data)
+fit_rf <- ml_rf(ml_data)
+fit_svm <- ml_svm_rfe(ml_data)
+fit_xgb <- ml_xgboost(ml_data)
+```
+
+### ML visualization
+
+Use:
+
+- `plot_enet_cv()`, `plot_enet_path()`, `plot_enet_coefs()`
+- `plot_rf_boruta()`, `plot_rf_importance()`
+- `plot_svm_rfe_curve()`
+- `plot_xgb_importance()`
+- `plot_ml_venn()`, `plot_ml_roc()`
+
+### Modes B and C
+
+Use internal train/test split when the user has one dataset and asks for validation. Use external validation when the user provides separate training and validation datasets.
+
+### Post-hoc feature trimming and manual assembly
+
+Use `select_features()`, `create_tcm_ml_list()`, and `get_ml_gene_sets()` to assemble or trim models.
+
+### Single-gene diagnostic analysis
+
+Use ROC and group expression plots for candidate biomarkers.
+
+```r
+auc_tbl <- get_gene_auc(genes = consensus$gene, expr_mat = expr, group = group)
+p_roc <- plot_gene_roc(genes = consensus$gene[1:4], expr_mat = expr, group = group)
+p_box <- plot_gene_boxplot(genes = consensus$gene[1:4], expr_mat = expr, group = group)
+```
+
+## 9. AI Module
+
+### Setup
+
+Use `tcm_setup()` for model configuration. Set `skip_internet_check = TRUE` in proxy or TUN environments when endpoint checks pass but `curl::has_internet()` misfires.
+
+```r
+tcm_setup(
+  provider = "openai",
+  api_key = Sys.getenv("OPENAI_API_KEY"),
+  model = "gpt-5.4-mini",
+  base_url = "https://www.packyapi.com/v1",
+  save = TRUE,
+  test = TRUE
+)
+```
+
+### Interpretation layer
+
+Use `tcm_interpret()`, `interpret_enrichment()`, `interpret_ppi()`, `interpret_table()`, and `draft_result_paragraph()` for grounded text.
+
+```r
+interpret_enrichment(kegg, language = "zh")
+interpret_ppi(ppi_metrics, language = "zh")
+draft_result_paragraph(kegg, result_type = "KEGG enrichment", language = "zh")
+```
+
+### Agent layer
+
+Use:
+
+- `tcm_agent()` for one-shot natural-language tasks.
+- `tcm_chat()` for interactive sessions.
+- `create_tcm_task_agent()` for programmatic sessions.
+- `create_tcm_tools()` to expose a bounded set of tools.
+
+### Artifact management
+
+Use `save_tcm_artifact()`, `load_tcm_artifact()`, `list_tcm_artifacts()`, `summarize_tcm_artifact()`, `artifact_exists()`, and `clear_tcm_artifacts()`.
+
+```r
+art <- save_tcm_artifact(kegg, artifact_type = "enrichment_result")
+kegg2 <- load_tcm_artifact(art$artifact_id)
+```
+
+### Skill management
+
+Use `tcm_init_skills()`, `tcm_use_skills()`, `tcm_skill_dir()`, `tcm_reset_skills()`, and `tcm_aisdk_skill()` when creating or switching custom skills.
+
+## 10. Other Resources
+
+### Additional databases
+
+When the user asks for transcription factor regulation, microbiota-host interactions, or external validation, keep these sources separate from TCMDATA-derived evidence and label them clearly.
+
+### TF-gene interactions
+
+Use external TF resources such as DoRothEA only when requested. Treat TF-target edges as regulatory evidence, not direct herb-target evidence.
+
+### Gut microbiota-host interactions
+
+Use GutMGene-style bacterium-metabolite-target relationships for gut-TCM integration requests. Visualize as Bacteria -> Metabolite -> Target networks.
+
+### Docking heatmap
+
+Use `ggdock()` for docking score matrices.
+
+```r
+p_dock <- ggdock(docking_matrix)
+```
+
+## 11. Full Pipeline Decision Tree
+
+```text
+User request
+  -> Herb/target lookup only: Section 1
+  -> Literature/evidence only: Section 2
+  -> Molecules/structures/docking: Sections 3 and 10
+  -> Disease targets or intersections: Section 4
+  -> Network figure: Section 5
+  -> GO/KEGG/Herb enrichment: Section 6
+  -> PPI/hub genes/modules/robustness: Section 7
+  -> Expression ML/biomarkers: Section 8
+  -> AI interpretation/chat/report: Section 9
+  -> Complete network pharmacology: Sections 1, 4, 7, 6, 5, 2, 9
+```
+
+For a complete herb-disease mechanism study, always compute common targets before PPI and enrichment.

--- a/inst/skills/tcm-network-pharmacology/scripts/generate_report.R
+++ b/inst/skills/tcm-network-pharmacology/scripts/generate_report.R
@@ -1,117 +1,52 @@
 #!/usr/bin/env Rscript
-# generate_report.R
-# Collects all artifacts from the current session and generates a structured
-# network pharmacology analysis report in Markdown format.
+# Generate a compact Markdown report from artifacts available in the current
+# TCMDATA R session. This script is best sourced from R after an agent run.
 #
-# Usage (by agent via execute_skill_script):
-#   Rscript generate_report.R [output_file]
-#
-# Expects TCMDATA to be loaded and artifacts to be available in the session.
+# Usage:
+#   source("inst/skills/tcm-network-pharmacology/scripts/generate_report.R")
+#   generate_tcm_artifact_report("network_pharmacology_report.md")
 
-args <- commandArgs(trailingOnly = TRUE)
-output_file <- if (length(args) >= 1) args[1] else "network_pharmacology_report.md"
-
-if (!requireNamespace("TCMDATA", quietly = TRUE)) {
-  stop("TCMDATA package is required.")
-}
-
-artifacts <- TCMDATA::list_tcm_artifacts()
-if (is.null(artifacts) || nrow(artifacts) == 0) {
-  stop("No artifacts found in current session. Run the analysis first.")
-}
-
-# Helper: find artifact by type or function name
-find_artifact <- function(type = NULL, func = NULL) {
-  if (!is.null(type)) {
-    idx <- which(artifacts$artifact_type == type)
-  } else if (!is.null(func)) {
-    idx <- which(artifacts$function_name == func)
-  } else {
-    return(NULL)
+generate_tcm_artifact_report <- function(output_file = "network_pharmacology_report.md",
+                                         max_lines = 8L) {
+  if (!requireNamespace("TCMDATA", quietly = TRUE)) {
+    stop("TCMDATA package is required.", call. = FALSE)
   }
-  if (length(idx) == 0) return(NULL)
-  # Return the latest one
-  TCMDATA::list_tcm_artifacts()$artifact_id[idx[length(idx)]]
-}
 
-# Collect sections
-sections <- list()
+  artifacts <- TCMDATA::list_tcm_artifacts()
+  if (is.null(artifacts) || nrow(artifacts) == 0L) {
+    stop("No artifacts found in the current TCMDATA session.", call. = FALSE)
+  }
 
-sections$header <- paste0(
-  "# Network Pharmacology Analysis Report\n\n",
-  "Generated: ", Sys.time(), "\n\n",
-  "---\n"
-)
-
-# Herb search
-herb_id <- find_artifact(func = "search_herb")
-if (!is.null(herb_id)) {
-  herb_art <- get(herb_id, envir = TCMDATA:::.artifact_env)
-  sections$herb <- sprintf(
-    "## 1. Herb Target Retrieval\n\n%s\n\n- Targets: %d unique genes\n",
-    herb_art$summary %||% "",
-    length(unique(herb_art$object$target))
+  lines <- c(
+    "# Network Pharmacology Analysis Report",
+    "",
+    paste("Generated:", as.character(Sys.time())),
+    "",
+    "## Artifact Summary",
+    ""
   )
+
+  for (i in seq_len(nrow(artifacts))) {
+    artifact_id <- artifacts$artifact_id[i]
+    artifact_type <- artifacts$artifact_type[i]
+    lines <- c(
+      lines,
+      paste0("### ", artifact_id, " (", artifact_type, ")"),
+      "",
+      "```text",
+      TCMDATA::summarize_tcm_artifact(artifact_id, max_lines = max_lines),
+      "```",
+      ""
+    )
+  }
+
+  writeLines(lines, output_file)
+  message(sprintf("Report written to: %s", normalizePath(output_file, mustWork = FALSE)))
+  invisible(output_file)
 }
 
-# Disease search
-disease_id <- find_artifact(func = "search_disease")
-if (!is.null(disease_id)) {
-  disease_art <- get(disease_id, envir = TCMDATA:::.artifact_env)
-  sections$disease <- sprintf(
-    "## 2. Disease Target Retrieval\n\n%s\n\n- Genes: %d\n",
-    disease_art$summary %||% "",
-    length(unique(disease_art$object$gene_id))
-  )
+if (sys.nframe() == 0L) {
+  args <- commandArgs(trailingOnly = TRUE)
+  output_file <- if (length(args) >= 1L) args[[1L]] else "network_pharmacology_report.md"
+  generate_tcm_artifact_report(output_file)
 }
-
-# Intersection
-intersect_id <- find_artifact(type = "intersection_result")
-if (!is.null(intersect_id)) {
-  int_art <- get(intersect_id, envir = TCMDATA:::.artifact_env)
-  sections$intersection <- sprintf(
-    "## 3. Target Intersection\n\n%s\n\n- Common targets: %d\n",
-    int_art$summary %||% "",
-    length(int_art$object$intersection)
-  )
-}
-
-# PPI
-ppi_id <- find_artifact(func = "rank_ppi_nodes")
-if (is.null(ppi_id)) ppi_id <- find_artifact(type = "ppi_network")
-if (!is.null(ppi_id)) {
-  ppi_art <- get(ppi_id, envir = TCMDATA:::.artifact_env)
-  sections$ppi <- sprintf(
-    "## 4. PPI Network & Hub Genes\n\n%s\n",
-    ppi_art$summary %||% ""
-  )
-}
-
-# Enrichment
-go_id <- find_artifact(func = "run_go_enrichment")
-kegg_id <- find_artifact(func = "run_kegg_enrichment")
-enrich_text <- "## 5. Functional Enrichment\n\n"
-if (!is.null(go_id)) {
-  go_art <- get(go_id, envir = TCMDATA:::.artifact_env)
-  enrich_text <- paste0(enrich_text, "### GO-BP\n\n", go_art$summary %||% "", "\n\n")
-}
-if (!is.null(kegg_id)) {
-  kegg_art <- get(kegg_id, envir = TCMDATA:::.artifact_env)
-  enrich_text <- paste0(enrich_text, "### KEGG\n\n", kegg_art$summary %||% "", "\n\n")
-}
-sections$enrichment <- enrich_text
-
-# PubMed
-pubmed_id <- find_artifact(func = "get_pubmed_data")
-if (!is.null(pubmed_id)) {
-  pub_art <- get(pubmed_id, envir = TCMDATA:::.artifact_env)
-  sections$pubmed <- sprintf(
-    "## 6. Literature Validation\n\n%s\n",
-    pub_art$summary %||% ""
-  )
-}
-
-# Write report
-report <- paste(unlist(sections), collapse = "\n\n")
-writeLines(report, output_file)
-cat(sprintf("Report written to: %s (%d bytes)\n", output_file, nchar(report)))

--- a/man/tcm_chat.Rd
+++ b/man/tcm_chat.Rd
@@ -15,10 +15,10 @@ tcm_chat(model = NULL, verbose = TRUE, stream = TRUE, skills = NULL)
 at runtime with the \code{/stream} command.}
 
 \item{skills}{Character vector of skill directories to load for the chat
-session. Default \code{NULL} uses the active TCMDATA skill directory
-(scanning all skills under it) plus aisdk's \code{skill-creator} skill
-if available. Use \code{character(0)} to disable skills, or pass an
-explicit vector to override the default.}
+session. Default \code{NULL} disables aisdk skills for chat stability and
+uses TCMDATA's built-in tool-oriented system prompt. Pass explicit skill
+paths, for example \code{c(tcm_skill_dir(), tcm_aisdk_skill())}, to enable
+skill loading.}
 }
 \value{
 Invisibly returns a list with \code{history} (each turn's task and

--- a/man/tcm_setup.Rd
+++ b/man/tcm_setup.Rd
@@ -12,7 +12,8 @@ tcm_setup(
   .env = TRUE,
   save = FALSE,
   test = FALSE,
-  force_json_schema = TRUE
+  force_json_schema = TRUE,
+  skip_internet_check = TRUE
 )
 }
 \arguments{
@@ -44,6 +45,11 @@ contains the schema instruction (some 3rd-party relay APIs silently strip
 the system message when \code{response_format} is absent).
 Set \code{FALSE} only when targeting a provider whose API rejects an
 unknown \code{response_format} field entirely.}
+
+\item{skip_internet_check}{Logical. Default \code{TRUE}. Sets
+\code{options(aisdk.skip_internet_check = TRUE)} before live requests so
+\code{curl::has_internet()} false negatives in proxy/VPN environments do
+not block otherwise reachable API endpoints.}
 }
 \value{
 The model object, invisibly.

--- a/tests/testthat/test-ai.R
+++ b/tests/testthat/test-ai.R
@@ -239,6 +239,137 @@ test_that("custom is absent from provider whitelist", {
   expect_true("gemini"    %in% providers)
 })
 
+test_that("tcm_setup enables aisdk internet-check bypass by default", {
+  skip_if_not_installed("aisdk")
+
+  fake_provider <- list(
+    language_model = function(model_id) {
+      structure(
+        list(model_id = model_id, provider = "openai"),
+        class = "LanguageModelV1"
+      )
+    }
+  )
+
+  local_mocked_bindings(
+    create_openai = function(...) fake_provider,
+    set_model = function(model) invisible(NULL),
+    .package = "aisdk"
+  )
+
+  old <- getOption("aisdk.skip_internet_check", NULL)
+  on.exit(options(aisdk.skip_internet_check = old), add = TRUE)
+  options(aisdk.skip_internet_check = FALSE)
+
+  tcm_setup(
+    provider = "openai",
+    api_key = "test-key",
+    model = "test-model",
+    test = FALSE
+  )
+
+  expect_true(isTRUE(getOption("aisdk.skip_internet_check")))
+})
+
+test_that("tcm_setup test request omits temperature for proxy compatibility", {
+  skip_if_not_installed("aisdk")
+
+  fake_provider <- list(
+    language_model = function(model_id) {
+      structure(
+        list(model_id = model_id, provider = "openai"),
+        class = "LanguageModelV1"
+      )
+    }
+  )
+  captured <- list()
+
+  local_mocked_bindings(
+    create_openai = function(...) fake_provider,
+    set_model = function(model) invisible(NULL),
+    generate_text = function(...) {
+      captured$args <<- list(...)
+      list(text = "pong")
+    },
+    .package = "aisdk"
+  )
+
+  tcm_setup(
+    provider = "openai",
+    api_key = "test-key",
+    model = "test-model",
+    test = TRUE
+  )
+
+  expect_true("temperature" %in% names(captured$args))
+  expect_null(captured$args$temperature)
+})
+
+test_that(".send_tcm_chat_turn falls back when streaming fails", {
+  skip_if_not_installed("aisdk")
+
+  failing_stream_session <- list(
+    send_stream = function(prompt, callback, ...) {
+      stop("stream failed")
+    },
+    get_last_response = function() ""
+  )
+  fallback_session <- list(
+    send = function(prompt, ...) {
+      captured$send_args <<- list(...)
+      list(text = paste("batch", prompt), tool_calls = list())
+    }
+  )
+  captured <- list()
+
+  local_mocked_bindings(
+    create_chat_session = function(agent, model) fallback_session,
+    .package = "aisdk"
+  )
+
+  saw_stream_error <- FALSE
+  out <- .send_tcm_chat_turn(
+    chat_session = failing_stream_session,
+    session_agent = list(),
+    model = "mock-model",
+    prompt = "hello",
+    stream = TRUE,
+    on_stream_error = function(e) {
+      saw_stream_error <<- TRUE
+    }
+  )
+
+  expect_true(saw_stream_error)
+  expect_true(isTRUE(out$fallback))
+  expect_equal(out$result$text, "batch hello")
+  expect_identical(out$chat_session, fallback_session)
+  expect_true("temperature" %in% names(captured$send_args))
+  expect_null(captured$send_args$temperature)
+})
+
+test_that(".send_tcm_chat_turn omits temperature for batch chat", {
+  captured <- list()
+  batch_session <- list(
+    send = function(prompt, ...) {
+      captured$send_args <<- list(...)
+      list(text = "batch ok", tool_calls = list())
+    }
+  )
+
+  out <- .send_tcm_chat_turn(
+    chat_session = batch_session,
+    session_agent = list(),
+    model = "mock-model",
+    prompt = "hello",
+    stream = FALSE
+  )
+
+  expect_false(isTRUE(out$fallback))
+  expect_equal(out$result$text, "batch ok")
+  expect_true("temperature" %in% names(captured$send_args))
+  expect_null(captured$send_args$temperature)
+})
+
 # ── Regression: artifacts, tools, routing ───────────────────────────────────
 
 test_that("artifact registry keeps artifact metadata", {
@@ -257,6 +388,36 @@ test_that("artifact registry keeps artifact metadata", {
   expect_equal(nrow(row), 1)
   expect_equal(row$artifact_type, "table_result")
   expect_equal(row$r_class, "data.frame")
+})
+
+test_that("tool artifacts are immediately available to eval_r_code", {
+  skip_if_not_installed("aisdk")
+
+  clear_tcm_artifacts()
+  on.exit(clear_tcm_artifacts(), add = TRUE)
+
+  result <- .save_tool_artifact(
+    object = data.frame(target = c("TP53", "AKT1"), stringsAsFactors = FALSE),
+    artifact_type = "search_result",
+    function_name = "unit_test"
+  )
+  on.exit(
+    if (exists(result$artifact_id, envir = globalenv(), inherits = FALSE)) {
+      rm(list = result$artifact_id, envir = globalenv())
+    },
+    add = TRUE
+  )
+
+  expect_true(exists(result$artifact_id, envir = globalenv(), inherits = FALSE))
+
+  code <- sprintf(
+    "df <- get('%s', envir = .GlobalEnv); cat(paste(unique(df$target), collapse = ','))",
+    result$artifact_id
+  )
+  eval_result <- tool_eval_r_code()$run(list(code = code))
+
+  expect_true(isTRUE(eval_result$ok))
+  expect_true(grepl("TP53,AKT1", eval_result$output, fixed = TRUE))
 })
 
 test_that("create_tcm_tools exposes expanded tool modules", {


### PR DESCRIPTION
## 主要更新

本次 PR 主要修复 AI 模块在实际使用中的若干稳定性问题，并重写了内置的网络药理学分析 skill。

## 修改内容

- 将 `aisdk` 调整为使用 CRAN 版本，移除 GitHub Remotes 依赖。
- 修复代理/TUN 网络环境下 `curl::has_internet()` 误判导致的连接检查问题。
- 修复部分 OpenAI-compatible API 在 `tcm_setup(test=TRUE)`、`tcm_chat()`、stream fallback 中返回 400 的问题。
- 修复 `tcm_chat()` 默认加载 skill 时可能触发空 `load_skill {}` 调用的问题。
- 修复同一轮对话中工具生成的 artifact 不能被后续 `eval_r_code()` 读取的问题。
- 改进 `eval_r_code()` 的错误返回逻辑，避免执行失败却显示为 `ok = TRUE`。
- 重写 `tcm-network-pharmacology` skill，补充完整工作流、函数参数说明、使用示例、文档章节索引和绘图风格参考。

